### PR TITLE
Add actions for managing applicants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
 script:
   - yarn test
   - yarn inspect
+  - yarn build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official Node.js library for integrating with the Onfido API.
 
 Documentation can be found at <https://documentation.onfido.com>
 
-This library is only for use with Node on the backend, as it uses Onfido API tokens which must be kept secret. If you do need to collect applicant data in the frontend of your application, we recommend that you use one of [the Onfido SDKs](https://developers.onfido.com/sdks/).
+This library is only for use on the backend, as it uses Onfido API tokens which must be kept secret. If you do need to collect applicant data in the frontend of your application, we recommend that you use one of [the Onfido SDKs](https://developers.onfido.com/sdks/).
 
 ## Installation
 
@@ -16,7 +16,7 @@ For npm:
 npm install @onfido/api
 ```
 
-For yarn:
+For Yarn:
 
 ```sh
 yarn add @onfido/api
@@ -89,7 +89,7 @@ onfido.applicant
     })
   )
   .then(check =>
-    ...
+    // Handle successfully created check.
   )
   .catch(error => {
     // Handle error.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
 # Work In Progress - Onfido Node.js Library
+
+:warning: **Under development**
+
+The official Node.js library for integrating with the Onfido API.
+
+Documentation can be found at <https://documentation.onfido.com>
+
+This library is only for use with Node on the backend, as it uses Onfido API tokens which must be kept secret. If you do need to collect applicant data in the frontend of your application, we recommend that you use one of [the Onfido SDKs](https://developers.onfido.com/sdks/).
+
+## Installation
+
+For npm:
+
+```sh
+npm install @onfido/api
+```
+
+For yarn:
+
+```sh
+yarn add @onfido/api
+```
+
+## Getting Started
+
+Require the package:
+
+```js
+const { Onfido, Region } = require("@onfido/api");
+```
+
+For TypeScript users, types are available as well:
+
+```ts
+import { Onfido, Region, Applicant, OnfidoApiError } from "@onfido/api";
+```
+
+Configure with you API token, and region if necessary:
+
+```js
+const onfido = new Onfido({
+  apiToken: process.env.ONFIDO_API_TOKEN
+  // Defaults to EU region (api.onfido.com)
+  // region: Region.US
+});
+```
+
+Using with `async`/`await` (in an `async function`):
+
+```js
+try {
+  const applicant = await onfido.applicant.create({
+    firstName: "Jane",
+    lastName: "Doe"
+  });
+
+  const check = await onfido.check.create({
+    applicantId: applicant.id,
+    reportNames: ["identity_enhanced"]
+  });
+
+  return check;
+} catch (error) {
+  if (error instanceof OnfidoApiError) {
+    // An error response was received from the Onfido API, extra info is available.
+    console.log(error.message);
+    console.log(error.type);
+    console.log(error.isClientError());
+  } else {
+    // No response was received for some reason e.g. a network error.
+    console.log(error.message);
+  }
+}
+```
+
+Using with promises:
+
+```js
+onfido.applicant
+  .create({
+    firstName: "Jane",
+    lastName: "Doe"
+  })
+  .then(applicant =>
+    onfido.check.create({
+      applicantId: applicant.id,
+      reportNames: ["identity_enhanced"]
+    })
+  )
+  .then(check =>
+    ...
+  )
+  .catch(error => {
+    // Handle error.
+  });
+```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "@onfido/api",
   "version": "0.1.0",
   "description": "Node.js library for the Onfido API",
-  "keywords": ["onfido", "identity", "verification", "api"],
+  "keywords": [
+    "onfido",
+    "identity",
+    "verification",
+    "api"
+  ],
   "homepage": "https://github.com/onfido/onfido-node#readme",
   "license": "MIT",
   "author": "Onfido <api@onfido.com> (https://documentation.onfido.com)",
@@ -18,19 +23,25 @@
     "build": "rollup -c rollup.config.ts",
     "test": "jest",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
-    "inspect": "tslint 'src/**/*.ts' 'test/**/*.ts'",
+    "inspect": "tslint 'src/**/*.ts' 'test/**/*.ts' && prettier --check README.md",
     "format": "tslint 'src/**/*.ts' 'test/**/*.ts' --fix && prettier --write README.md"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "onfido-node/(.*)": "<rootDir>/src/$1"
+      "onfido-node": "<rootDir>/src/index"
+    },
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "test/tsconfig.json"
+      }
     }
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
     "jest": "^24.9.0",
+    "nock": "^11.7.0",
     "prettier": "^1.18.2",
     "rollup": "^1.24.0",
     "rollup-plugin-typescript2": "^0.25.3",
@@ -39,5 +50,8 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.6.4"
+  },
+  "dependencies": {
+    "axios": "^0.19.0"
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,5 +14,6 @@ export default {
       sourcemap: true
     }
   ],
-  plugins: [typescript()]
+  plugins: [typescript()],
+  external: ["axios"]
 };

--- a/src/Hello.ts
+++ b/src/Hello.ts
@@ -1,5 +1,0 @@
-export class Hello {
-  public world() {
-    return "Hello, world!";
-  }
-}

--- a/src/Onfido.ts
+++ b/src/Onfido.ts
@@ -14,8 +14,8 @@ export type OnfidoOptions = {
 };
 
 const apiUrls = {
-  EU: "https://api.onfido.com/v3/",
-  US: "https://api.us.onfido.com/v3/"
+  [Region.EU]: "https://api.onfido.com/v3/",
+  [Region.US]: "https://api.us.onfido.com/v3/"
 };
 
 export class Onfido {

--- a/src/Onfido.ts
+++ b/src/Onfido.ts
@@ -1,0 +1,47 @@
+import axios, { AxiosInstance } from "axios";
+import { Applicants } from "./resources/Applicants";
+
+export enum Region {
+  EU = "EU",
+  US = "US"
+}
+
+export type OnfidoOptions = {
+  apiToken: string;
+  region?: Region;
+  timeout?: number;
+  unknownApiUrl?: string;
+};
+
+const apiUrls = {
+  EU: "https://api.onfido.com/v3/",
+  US: "https://api.us.onfido.com/v3/"
+};
+
+export class Onfido {
+  public readonly applicant: Applicants;
+  public readonly axiosInstance: AxiosInstance;
+
+  constructor({
+    apiToken,
+    region = Region.EU,
+    timeout = 30_000,
+    unknownApiUrl
+  }: OnfidoOptions) {
+    const regionUrl = apiUrls[region];
+    if (!regionUrl) {
+      throw new Error("Unknown region " + region);
+    }
+
+    this.axiosInstance = axios.create({
+      baseURL: unknownApiUrl || regionUrl,
+      headers: {
+        Authorization: `Token token=${apiToken}`,
+        Accept: "application/json"
+      },
+      timeout
+    });
+
+    this.applicant = new Applicants(this.axiosInstance);
+  }
+}

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -34,15 +34,22 @@ export class Resource<T extends SimpleObject> {
     this.axiosInstance = axiosInstance;
   }
 
-  protected async request(
-    method: Method,
-    path: string,
-    body?: T
-  ): Promise<any> {
+  protected async request({
+    method,
+    path = "",
+    body,
+    query
+  }: {
+    method: Method;
+    path?: string;
+    body?: T;
+    query?: SimpleObject;
+  }): Promise<any> {
     const promise = this.axiosInstance({
       method,
       url: `${this.name}/${path}`,
-      data: body && formatRequest(body)
+      data: body && formatRequest(body),
+      params: query && formatRequest(query)
     });
 
     let response;

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -56,14 +56,13 @@ export class Resource<T extends SimpleObject> {
       params: query && convertObjectToSnakeCase(query)
     });
 
-    let response;
     try {
-      response = await promise;
+      const response = await promise;
+
+      const data = response.data;
+      return isJson(response) ? convertObjectToCamelCase(data) : data;
     } catch (error) {
       throw convertAxiosErrorToOnfidoError(error);
     }
-
-    const data = response.data;
-    return isJson(response) ? convertObjectToCamelCase(data) : data;
   }
 }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,7 +1,11 @@
 import { AxiosInstance, AxiosResponse } from "axios";
 import { OnfidoApiError } from "./errors/OnfidoApiError";
 import { OnfidoError } from "./errors/OnfidoError";
-import { formatRequest, formatResponse, SimpleObject } from "./formatting";
+import {
+  convertObjectToCamelCase,
+  convertObjectToSnakeCase,
+  SimpleObject
+} from "./formatting";
 
 export enum Method {
   GET = "get",
@@ -48,8 +52,8 @@ export class Resource<T extends SimpleObject> {
     const promise = this.axiosInstance({
       method,
       url: `${this.name}/${path}`,
-      data: body && formatRequest(body),
-      params: query && formatRequest(query)
+      data: body && convertObjectToSnakeCase(body),
+      params: query && convertObjectToSnakeCase(query)
     });
 
     let response;
@@ -60,6 +64,6 @@ export class Resource<T extends SimpleObject> {
     }
 
     const data = response.data;
-    return isJson(response) ? formatResponse(data) : data;
+    return isJson(response) ? convertObjectToCamelCase(data) : data;
   }
 }

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,0 +1,58 @@
+import { AxiosInstance, AxiosResponse } from "axios";
+import { OnfidoApiError } from "./errors/OnfidoApiError";
+import { OnfidoError } from "./errors/OnfidoError";
+import { formatRequest, formatResponse, SimpleObject } from "./formatting";
+
+export enum Method {
+  GET = "get",
+  POST = "post",
+  PUT = "put",
+  DELETE = "delete"
+}
+
+const isJson = (response: AxiosResponse<unknown>): boolean =>
+  (response.headers["content-type"] || "").includes("application/json");
+
+const convertAxiosErrorToOnfidoError = (error: any): OnfidoError => {
+  if (error.response) {
+    // Received a 4XX or 5XX response.
+    const response: AxiosResponse = error.response;
+    return OnfidoApiError.fromResponse(response.data, response.status);
+  } else if (error.message) {
+    return new OnfidoError(error.message);
+  } else {
+    return new OnfidoError("An unknown error occurred making the request");
+  }
+};
+
+export class Resource<T extends SimpleObject> {
+  private readonly name: string;
+  private readonly axiosInstance: AxiosInstance;
+
+  protected constructor(name: string, axiosInstance: AxiosInstance) {
+    this.name = name;
+    this.axiosInstance = axiosInstance;
+  }
+
+  protected async request(
+    method: Method,
+    path: string,
+    body?: T
+  ): Promise<any> {
+    const promise = this.axiosInstance({
+      method,
+      url: `${this.name}/${path}`,
+      data: body && formatRequest(body)
+    });
+
+    let response;
+    try {
+      response = await promise;
+    } catch (error) {
+      throw convertAxiosErrorToOnfidoError(error);
+    }
+
+    const data = response.data;
+    return isJson(response) ? formatResponse(data) : data;
+  }
+}

--- a/src/errors/OnfidoApiError.ts
+++ b/src/errors/OnfidoApiError.ts
@@ -1,0 +1,58 @@
+import { OnfidoError } from "./OnfidoError";
+
+export class OnfidoApiError extends OnfidoError {
+  public readonly responseBody: unknown;
+  public readonly statusCode: number;
+  public readonly type: string;
+  public readonly fields: unknown;
+
+  private constructor(
+    message: string,
+    responseBody: unknown,
+    statusCode: number,
+    type: string,
+    fields: unknown
+  ) {
+    super(message);
+    this.name = "OnfidoApiError";
+
+    this.responseBody = responseBody;
+    this.statusCode = statusCode;
+    this.type = type;
+    this.fields = fields;
+  }
+
+  public static fromResponse(
+    responseBody: unknown,
+    statusCode: number
+  ): OnfidoApiError {
+    const innerErrorData: unknown =
+      responseBody instanceof Object ? (responseBody as any).error : {};
+
+    const innerError: {
+      type?: unknown;
+      message?: unknown;
+      fields?: unknown;
+    } = innerErrorData instanceof Object ? innerErrorData : {};
+
+    const type = `${innerError.type || "unknown"}`;
+    const message = `${innerError.message || responseBody}`;
+    const fields = innerError.fields;
+
+    const fullMessage =
+      `${message} (status code ${statusCode})` +
+      (fields ? ` | ${JSON.stringify(fields)}` : "");
+
+    return new OnfidoApiError(
+      fullMessage,
+      responseBody,
+      statusCode,
+      type,
+      fields
+    );
+  }
+
+  public isClientError(): boolean {
+    return this.statusCode < 500;
+  }
+}

--- a/src/errors/OnfidoError.ts
+++ b/src/errors/OnfidoError.ts
@@ -1,0 +1,6 @@
+export class OnfidoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OnfidoError";
+  }
+}

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,0 +1,40 @@
+export type SimpleObject = { [key: string]: unknown };
+
+const deepMapObjectKeys = (value: unknown, f: (key: string) => string): any => {
+  if (!(value instanceof Object)) {
+    return value;
+  } else if (Array.isArray(value)) {
+    return value.map(item => deepMapObjectKeys(item, f));
+  } else {
+    const acc: SimpleObject = {};
+    Object.keys(value).forEach(key => {
+      acc[f(key)] = deepMapObjectKeys((value as SimpleObject)[key], f);
+    });
+    return acc;
+  }
+};
+
+export const formatRequest = (requestBody: unknown): unknown => {
+  // Convert to JSON and back first to simplify.
+  requestBody = JSON.parse(JSON.stringify(requestBody));
+
+  return deepMapObjectKeys(requestBody, key =>
+    key.replace(/[A-Z]/g, char => `_${char.toLowerCase()}`)
+  );
+};
+
+export const formatResponse = (responseBody: SimpleObject): SimpleObject =>
+  deepMapObjectKeys(responseBody, key =>
+    key.replace(/_[a-z]/g, underscoreChar => underscoreChar[1].toUpperCase())
+  );
+
+export const toQueryString = (object: {
+  [key: string]: string | number | boolean | null | undefined;
+}): string => {
+  const queryString = Object.entries(object)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value!)}`)
+    .join("&");
+
+  return queryString === "" ? "" : `?${queryString}`;
+};

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -19,12 +19,13 @@ const deepMapObjectKeys = (value: unknown, f: (key: string) => string): any => {
   }
 };
 
-export const formatRequest = (requestBody: unknown): unknown => {
+export const convertObjectToSnakeCase = (requestBody: unknown): unknown => {
   // Convert to JSON and back first to simplify.
   requestBody = JSON.parse(JSON.stringify(requestBody));
 
   return deepMapObjectKeys(requestBody, snakeCase);
 };
 
-export const formatResponse = (responseBody: SimpleObject): SimpleObject =>
-  deepMapObjectKeys(responseBody, camelCase);
+export const convertObjectToCamelCase = (
+  responseBody: SimpleObject
+): SimpleObject => deepMapObjectKeys(responseBody, camelCase);

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -20,7 +20,7 @@ const deepMapObjectKeys = (value: unknown, f: (key: string) => string): any => {
 };
 
 export const convertObjectToSnakeCase = (requestBody: unknown): unknown => {
-  // Convert to JSON and back first to simplify.
+  // Converting to JSON and back first handles things like dates, circular references etc.
   requestBody = JSON.parse(JSON.stringify(requestBody));
 
   return deepMapObjectKeys(requestBody, snakeCase);

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,16 +1,21 @@
 export type SimpleObject = { [key: string]: unknown };
 
+const snakeCase = (s: string): string =>
+  s.replace(/[A-Z]/g, char => `_${char.toLowerCase()}`);
+
+const camelCase = (s: string): string =>
+  s.replace(/_[a-z]/g, underscoreChar => underscoreChar[1].toUpperCase());
+
 const deepMapObjectKeys = (value: unknown, f: (key: string) => string): any => {
   if (!(value instanceof Object)) {
     return value;
   } else if (Array.isArray(value)) {
     return value.map(item => deepMapObjectKeys(item, f));
   } else {
-    const acc: SimpleObject = {};
-    Object.keys(value).forEach(key => {
+    return Object.keys(value).reduce<SimpleObject>((acc, key) => {
       acc[f(key)] = deepMapObjectKeys((value as SimpleObject)[key], f);
-    });
-    return acc;
+      return acc;
+    }, {});
   }
 };
 
@@ -18,23 +23,8 @@ export const formatRequest = (requestBody: unknown): unknown => {
   // Convert to JSON and back first to simplify.
   requestBody = JSON.parse(JSON.stringify(requestBody));
 
-  return deepMapObjectKeys(requestBody, key =>
-    key.replace(/[A-Z]/g, char => `_${char.toLowerCase()}`)
-  );
+  return deepMapObjectKeys(requestBody, snakeCase);
 };
 
 export const formatResponse = (responseBody: SimpleObject): SimpleObject =>
-  deepMapObjectKeys(responseBody, key =>
-    key.replace(/_[a-z]/g, underscoreChar => underscoreChar[1].toUpperCase())
-  );
-
-export const toQueryString = (object: {
-  [key: string]: string | number | boolean | null | undefined;
-}): string => {
-  const queryString = Object.entries(object)
-    .filter(([, value]) => value !== undefined && value !== null)
-    .map(([key, value]) => `${key}=${encodeURIComponent(value!)}`)
-    .join("&");
-
-  return queryString === "" ? "" : `?${queryString}`;
-};
+  deepMapObjectKeys(responseBody, camelCase);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
-export { Hello } from "./Hello";
+export { Onfido, OnfidoOptions, Region } from "./Onfido";
+
+export { Applicant, ApplicantRequest } from "./resources/Applicants";
+export { Address, AddressRequest } from "./resources/Addresses";
+export { IdNumber, IdNumberRequest } from "./resources/IdNumbers";
+
+export { OnfidoError } from "./errors/OnfidoError";
+export { OnfidoApiError } from "./errors/OnfidoApiError";

--- a/src/resources/Addresses.ts
+++ b/src/resources/Addresses.ts
@@ -1,0 +1,22 @@
+type AddressOptional = {
+  flatNumber: string | null;
+  buildingNumber: string | null;
+  buildingName: string | null;
+  street: string | null;
+  subStreet: string | null;
+  town: string | null;
+  state: string | null;
+  line1: string | null;
+  line2: string | null;
+  line3: string | null;
+};
+
+export type AddressRequest = {
+  postcode: string;
+  country: string;
+} & Partial<AddressOptional>;
+
+export type Address = {
+  postcode: string;
+  country: string;
+} & AddressOptional;

--- a/src/resources/Applicants.ts
+++ b/src/resources/Applicants.ts
@@ -1,0 +1,73 @@
+import { AxiosInstance } from "axios";
+import { toQueryString } from "../formatting";
+import { Method, Resource } from "../Resource";
+import { Address, AddressRequest } from "./Addresses";
+import { IdNumber, IdNumberRequest } from "./IdNumbers";
+
+// firstName and lastName are also optional, to allow updating.
+export type ApplicantRequest = {
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  dob?: string | null;
+  address?: AddressRequest | null;
+  idNumbers?: IdNumberRequest[] | null;
+};
+
+export type Applicant = {
+  id: string;
+  createdAt: string;
+  deleteAt: string | null;
+  href: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  dob: string | null;
+  address: Address | null;
+  idNumbers: IdNumber[] | null;
+};
+
+export class Applicants extends Resource<ApplicantRequest> {
+  constructor(axiosInstance: AxiosInstance) {
+    super("applicants", axiosInstance);
+  }
+
+  public async create(applicantRequest: ApplicantRequest): Promise<Applicant> {
+    return this.request(Method.POST, "", applicantRequest);
+  }
+
+  public async find(id: string): Promise<Applicant> {
+    return this.request(Method.GET, id);
+  }
+
+  public async update(
+    id: string,
+    applicantRequest: ApplicantRequest
+  ): Promise<Applicant> {
+    return this.request(Method.PUT, id, applicantRequest);
+  }
+
+  public async delete(id: string): Promise<void> {
+    await this.request(Method.DELETE, id);
+  }
+
+  public async restore(id: string): Promise<void> {
+    await this.request(Method.POST, `${id}/restore`);
+  }
+
+  public async list({
+    page,
+    perPage,
+    includeDeleted
+  }: {
+    page?: number;
+    perPage?: number;
+    includeDeleted?: boolean;
+  } = {}): Promise<Applicant[]> {
+    const { applicants } = await this.request(
+      Method.GET,
+      toQueryString({ page, perPage, includeDeleted })
+    );
+    return applicants;
+  }
+}

--- a/src/resources/Applicants.ts
+++ b/src/resources/Applicants.ts
@@ -1,5 +1,4 @@
 import { AxiosInstance } from "axios";
-import { toQueryString } from "../formatting";
 import { Method, Resource } from "../Resource";
 import { Address, AddressRequest } from "./Addresses";
 import { IdNumber, IdNumberRequest } from "./IdNumbers";
@@ -33,26 +32,30 @@ export class Applicants extends Resource<ApplicantRequest> {
   }
 
   public async create(applicantRequest: ApplicantRequest): Promise<Applicant> {
-    return this.request(Method.POST, "", applicantRequest);
+    return this.request({ method: Method.POST, body: applicantRequest });
   }
 
   public async find(id: string): Promise<Applicant> {
-    return this.request(Method.GET, id);
+    return this.request({ method: Method.GET, path: id });
   }
 
   public async update(
     id: string,
     applicantRequest: ApplicantRequest
   ): Promise<Applicant> {
-    return this.request(Method.PUT, id, applicantRequest);
+    return this.request({
+      method: Method.PUT,
+      path: id,
+      body: applicantRequest
+    });
   }
 
   public async delete(id: string): Promise<void> {
-    await this.request(Method.DELETE, id);
+    await this.request({ method: Method.DELETE, path: id });
   }
 
   public async restore(id: string): Promise<void> {
-    await this.request(Method.POST, `${id}/restore`);
+    await this.request({ method: Method.POST, path: `${id}/restore` });
   }
 
   public async list({
@@ -64,10 +67,11 @@ export class Applicants extends Resource<ApplicantRequest> {
     perPage?: number;
     includeDeleted?: boolean;
   } = {}): Promise<Applicant[]> {
-    const { applicants } = await this.request(
-      Method.GET,
-      toQueryString({ page, perPage, includeDeleted })
-    );
+    const { applicants } = await this.request({
+      method: Method.GET,
+      query: { page, perPage, includeDeleted }
+    });
+
     return applicants;
   }
 }

--- a/src/resources/IdNumbers.ts
+++ b/src/resources/IdNumbers.ts
@@ -1,0 +1,11 @@
+export type IdNumberRequest = {
+  type: string;
+  value: string;
+  stateCode?: string | null;
+};
+
+export type IdNumber = {
+  type: string;
+  value: string;
+  stateCode: string | null;
+};

--- a/test/Hello.test.ts
+++ b/test/Hello.test.ts
@@ -1,5 +1,0 @@
-import { Hello } from "onfido-node/Hello";
-
-it("returns hello world", () => {
-  expect(new Hello().world()).toEqual("Hello, world!");
-});

--- a/test/Onfido.test.ts
+++ b/test/Onfido.test.ts
@@ -1,0 +1,33 @@
+import { Onfido, Region } from "onfido-node";
+
+it("sets the authorization header from the given token", () => {
+  const onfido = new Onfido({ apiToken: "api_token" });
+  expect(onfido.axiosInstance.defaults.headers.Authorization).toBe(
+    "Token token=api_token"
+  );
+});
+
+it("defaults to the EU region", () => {
+  const onfido = new Onfido({ apiToken: "token" });
+  expect(onfido.axiosInstance.defaults.baseURL).toBe(
+    "https://api.onfido.com/v3/"
+  );
+});
+
+it("allows setting the region", () => {
+  const onfido = new Onfido({ apiToken: "token", region: Region.US });
+  expect(onfido.axiosInstance.defaults.baseURL).toBe(
+    "https://api.us.onfido.com/v3/"
+  );
+});
+
+it("throws an error for unknown regions", () => {
+  expect(() => new Onfido({ apiToken: "token", region: "abc" as any })).toThrow(
+    "Unknown region abc"
+  );
+});
+
+it("allows changing the default timeout", () => {
+  const onfido = new Onfido({ apiToken: "token", timeout: 123 });
+  expect(onfido.axiosInstance.defaults.timeout).toBe(123);
+});

--- a/test/errors/OnfidoApiError.test.ts
+++ b/test/errors/OnfidoApiError.test.ts
@@ -1,0 +1,40 @@
+import { OnfidoApiError } from "onfido-node";
+
+it("extracts the type, message and fields", () => {
+  const error = OnfidoApiError.fromResponse(
+    {
+      error: {
+        type: "the_type",
+        message: "the message",
+        fields: {
+          field: "error"
+        }
+      }
+    },
+    500
+  );
+
+  expect(error.type).toBe("the_type");
+  expect(error.message).toBe(
+    'the message (status code 500) | {"field":"error"}'
+  );
+  expect(error.fields).toEqual({ field: "error" });
+});
+
+it("has the original response body and status code", () => {
+  const error = OnfidoApiError.fromResponse("Not Found", 404);
+  expect(error.responseBody).toBe("Not Found");
+  expect(error.statusCode).toBe(404);
+});
+
+it("handles response not having an error object", () => {
+  const error = OnfidoApiError.fromResponse("Unknown error", 500);
+  expect(error.type).toBe("unknown");
+  expect(error.message).toBe("Unknown error (status code 500)");
+  expect(error.fields).toBeUndefined();
+});
+
+it("indicates whether it was a client error", () => {
+  expect(OnfidoApiError.fromResponse("", 422).isClientError()).toBe(true);
+  expect(OnfidoApiError.fromResponse("", 500).isClientError()).toBe(false);
+});

--- a/test/errors/OnfidoError.test.ts
+++ b/test/errors/OnfidoError.test.ts
@@ -1,0 +1,6 @@
+import { OnfidoError } from "onfido-node";
+
+it("has a message", () => {
+  const error = new OnfidoError("the message");
+  expect(error.message).toBe("the message");
+});

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -1,0 +1,26 @@
+import {
+  convertObjectToCamelCase,
+  convertObjectToSnakeCase
+} from "../src/formatting";
+
+describe("formatRequest", () => {
+  it("converts keys to snake_case, even if nested", () => {
+    expect(
+      convertObjectToSnakeCase({
+        keyName: { nestedKey: 2 },
+        a: [{ nestedInArray: 1 }]
+      })
+    ).toEqual({ key_name: { nested_key: 2 }, a: [{ nested_in_array: 1 }] });
+  });
+});
+
+describe("formatResponse", () => {
+  it("converts keys to camelCase, even if nested", () => {
+    expect(
+      convertObjectToCamelCase({
+        key_name: { nested_key: 2 },
+        a: [{ nested_in_array: 1 }]
+      })
+    ).toEqual({ keyName: { nestedKey: 2 }, a: [{ nestedInArray: 1 }] });
+  });
+});

--- a/test/resources/Applicants.test.ts
+++ b/test/resources/Applicants.test.ts
@@ -122,8 +122,8 @@ it("lists applicants", async () => {
     .get("/applicants/")
     .query({
       page: 1,
-      perPage: 20,
-      includeDeleted: true
+      per_page: 20,
+      include_deleted: true
     })
     .reply(200, { applicants: [exampleApplicantJson, exampleApplicantJson] });
 
@@ -131,7 +131,7 @@ it("lists applicants", async () => {
     page: 1,
     perPage: 20,
     includeDeleted: true
-  });
+  } as any);
 
   expect(applicants).toEqual([exampleApplicant, exampleApplicant]);
 });

--- a/test/resources/Applicants.test.ts
+++ b/test/resources/Applicants.test.ts
@@ -1,0 +1,137 @@
+import nock from "nock";
+import { Applicant, Onfido } from "onfido-node";
+
+const onfido = new Onfido({ apiToken: "api_token" });
+
+const exampleApplicant: Applicant = {
+  id: "123-abc",
+  createdAt: "2020-01-01T00:00:00Z",
+  deleteAt: null,
+  href: "/v3/applicants/123-abc",
+  firstName: "Test",
+  lastName: "Applicant",
+  email: null,
+  dob: null,
+  idNumbers: [{ type: "type", value: "value", stateCode: null }],
+  address: {
+    postcode: "AB12 3AB",
+    country: "GBR",
+    flatNumber: null,
+    buildingNumber: null,
+    buildingName: null,
+    street: null,
+    subStreet: null,
+    town: null,
+    state: null,
+    line1: null,
+    line2: null,
+    line3: null
+  }
+};
+
+const exampleApplicantJson = {
+  id: "123-abc",
+  created_at: "2020-01-01T00:00:00Z",
+  delete_at: null,
+  href: "/v3/applicants/123-abc",
+  first_name: "Test",
+  last_name: "Applicant",
+  email: null,
+  dob: null,
+  id_numbers: [{ type: "type", value: "value", state_code: null }],
+  address: {
+    postcode: "AB12 3AB",
+    country: "GBR",
+    flat_number: null,
+    building_number: null,
+    building_name: null,
+    street: null,
+    sub_street: null,
+    town: null,
+    state: null,
+    line1: null,
+    line2: null,
+    line3: null
+  }
+};
+
+it("creates applicants", async () => {
+  nock("https://api.onfido.com/v3")
+    .post("/applicants/", {
+      first_name: "Test",
+      last_name: "Applicant",
+      address: {
+        postcode: "AB12 3AB",
+        country: "GBR"
+      }
+    })
+    .reply(201, exampleApplicantJson);
+
+  const applicant = await onfido.applicant.create({
+    firstName: "Test",
+    lastName: "Applicant",
+    address: {
+      postcode: "AB12 3AB",
+      country: "GBR"
+    }
+  });
+
+  expect(applicant).toEqual(exampleApplicant);
+});
+
+it("finds an applicant", async () => {
+  nock("https://api.onfido.com/v3")
+    .get("/applicants/123-abc")
+    .reply(200, exampleApplicantJson);
+
+  const applicant = await onfido.applicant.find("123-abc");
+
+  expect(applicant).toEqual(exampleApplicant);
+});
+
+it("updates an applicant", async () => {
+  nock("https://api.onfido.com/v3")
+    .put("/applicants/123-abc", { first_name: "Test2" })
+    .reply(200, exampleApplicantJson);
+
+  const applicant = await onfido.applicant.update("123-abc", {
+    firstName: "Test2"
+  });
+
+  expect(applicant).toEqual(exampleApplicant);
+});
+
+it("deletes an applicant", async () => {
+  nock("https://api.onfido.com/v3")
+    .delete("/applicants/123-abc")
+    .reply(204);
+
+  expect(await onfido.applicant.delete("123-abc")).toBeUndefined();
+});
+
+it("restores an applicant", async () => {
+  nock("https://api.onfido.com/v3")
+    .post("/applicants/123-abc/restore")
+    .reply(204);
+
+  expect(await onfido.applicant.restore("123-abc")).toBeUndefined();
+});
+
+it("lists applicants", async () => {
+  nock("https://api.onfido.com/v3")
+    .get("/applicants/")
+    .query({
+      page: 1,
+      perPage: 20,
+      includeDeleted: true
+    })
+    .reply(200, { applicants: [exampleApplicantJson, exampleApplicantJson] });
+
+  const applicants = await onfido.applicant.list({
+    page: 1,
+    perPage: 20,
+    includeDeleted: true
+  });
+
+  expect(applicants).toEqual([exampleApplicant, exampleApplicant]);
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "baseUrl": "../",
+    "paths": {
+      "onfido-node": ["src/index"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,15 +4,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "preserveConstEnums": true,
-    "target": "es5",
+    "target": "ES2017",
+    "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,
-    "esModuleInterop": true,
-    "baseUrl": "./",
-    "paths": {
-      "onfido-node/*": ["src/*"]
-    }
+    "esModuleInterop": true
   },
-  "include": ["src/"]
+  "include": ["src/**/*"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "prettier": true,
     "interface-over-type-literal": false,
     "member-ordering": [true, { "order": "fields-first" }],
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "typedef": [true, "call-signature", "arrow-call-signature"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,6 +513,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -547,6 +552,14 @@ aws4@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
   integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
+
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -713,6 +726,18 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -721,6 +746,11 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 chownr@^1.1.1:
   version "1.1.3"
@@ -869,6 +899,13 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -899,6 +936,13 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1232,6 +1276,13 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1310,6 +1361,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -1530,6 +1586,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -2158,7 +2219,7 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -2469,6 +2530,18 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nock@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-11.7.0.tgz#5eaae8b8a55c0dfc014d05692c8cf3d31d61a342"
+  integrity sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.13"
+    mkdirp "^0.5.0"
+    propagate "^2.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2777,6 +2850,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -2855,6 +2933,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 psl@^1.1.24, psl@^1.1.28:
   version "1.6.0"
@@ -3602,6 +3685,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 typescript@^3.6.4:
   version "3.7.3"


### PR DESCRIPTION
## Explanation

Add configuring an Onfido API client

Add creating, updating, listing, finding, deleting and restoring applicants.

Example:

```ts
const onfido = new Onfido({ apiToken: "..." });

const applicant = await onfido.applicant.create({
  firstName: "Jane",
  lastName: "Doe"
});
```

## Description

- Use axios for making requests
- I've added some functions to convert between snake_case and camelCase, so users can use e.g. `{ firstName: "..." }` rather than `{ first_name: "..." }`. They're in `src/formatting.ts`
- Add custom error classes to handle when we get an error json object from the API.

## Testing

I've used nock for testing the applicant endpoints, to make sure the correct request is being sent and the response is handled correctly. 

Unit tests for the custom error classes and for configuring the client.