### PR TITLE
Add uploading and downloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.19.0",
+    "form-data": "^3.0.0"
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -15,5 +15,5 @@ export default {
     }
   ],
   plugins: [typescript()],
-  external: ["axios"]
+  external: ["axios", "form-data", "stream"]
 };

--- a/src/Onfido.ts
+++ b/src/Onfido.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { Applicants } from "./resources/Applicants";
+import { Documents } from "./resources/Documents";
 
 export enum Region {
   EU = "EU",
@@ -20,6 +21,7 @@ const apiUrls = {
 
 export class Onfido {
   public readonly applicant: Applicants;
+  public readonly document: Documents;
   public readonly axiosInstance: AxiosInstance;
 
   constructor({
@@ -43,5 +45,6 @@ export class Onfido {
     });
 
     this.applicant = new Applicants(this.axiosInstance);
+    this.document = new Documents(this.axiosInstance);
   }
 }

--- a/src/OnfidoDownload.ts
+++ b/src/OnfidoDownload.ts
@@ -1,0 +1,21 @@
+import { IncomingMessage } from "http";
+import { PassThrough, Readable } from "stream";
+
+export class OnfidoDownload {
+  private readonly incomingMessage: IncomingMessage;
+
+  constructor(incomingMessage: IncomingMessage) {
+    this.incomingMessage = incomingMessage;
+  }
+
+  public asReadStream(): Readable {
+    // Use a PassThrough stream so the IncomingMessage isn't exposed.
+    const passThroughStream = new PassThrough();
+    this.incomingMessage.pipe(passThroughStream);
+    return passThroughStream;
+  }
+
+  public get contentType(): string {
+    return this.incomingMessage.headers["content-type"]!;
+  }
+}

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -28,6 +28,7 @@ const readFullStream = (stream: Readable): Promise<unknown> =>
     stream.on("data", data => (all += data));
     stream.on("error", () => resolve("An error occurred reading the response"));
     stream.on("end", () => {
+      // Try to parse as JSON, but fall back to just returning the raw text.
       try {
         resolve(JSON.parse(all));
       } catch {
@@ -113,6 +114,7 @@ export class Resource<T extends SimpleObject> {
       method: Method.GET,
       url: `${this.name}/${id}/download`,
       responseType: "stream",
+      // Accept a response with any content type (e.g. image/png, application/pdf, video/mp4)
       headers: { Accept: "*/*" }
     });
 

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,11 +1,15 @@
-import { AxiosInstance, AxiosResponse } from "axios";
+import { AxiosInstance, AxiosPromise, AxiosResponse } from "axios";
+import { IncomingMessage } from "http";
+import { Readable } from "stream";
 import { OnfidoApiError } from "./errors/OnfidoApiError";
 import { OnfidoError } from "./errors/OnfidoError";
 import {
   convertObjectToCamelCase,
   convertObjectToSnakeCase,
-  SimpleObject
+  SimpleObject,
+  toFormData
 } from "./formatting";
+import { OnfidoDownload } from "./OnfidoDownload";
 
 export enum Method {
   GET = "get",
@@ -17,15 +21,47 @@ export enum Method {
 const isJson = (response: AxiosResponse<unknown>): boolean =>
   (response.headers["content-type"] || "").includes("application/json");
 
-const convertAxiosErrorToOnfidoError = (error: any): OnfidoError => {
-  if (error.response) {
-    // Received a 4XX or 5XX response.
-    const response: AxiosResponse = error.response;
-    return OnfidoApiError.fromResponse(response.data, response.status);
-  } else if (error.message) {
-    return new OnfidoError(error.message);
-  } else {
-    return new OnfidoError("An unknown error occurred making the request");
+const readFullStream = (stream: Readable): Promise<unknown> =>
+  new Promise((resolve): void => {
+    let all = "";
+
+    stream.on("data", data => (all += data));
+    stream.on("error", () => resolve("An error occurred reading the response"));
+    stream.on("end", () => {
+      try {
+        resolve(JSON.parse(all));
+      } catch {
+        resolve(all);
+      }
+    });
+  });
+
+const convertAxiosErrorToOnfidoError = async (
+  error: any
+): Promise<OnfidoError> => {
+  if (!error.response) {
+    return new OnfidoError(
+      error.message || "An unknown error occurred making the request"
+    );
+  }
+
+  // Received a 4XX or 5XX response.
+  const response: AxiosResponse = error.response;
+  const data = response.data;
+
+  // If we were downloading a file, we will have a stream instead of a string.
+  const body = data instanceof Readable ? await readFullStream(data) : data;
+
+  return OnfidoApiError.fromResponse(body, response.status);
+};
+
+const handleResponse = async (request: AxiosPromise<any>): Promise<any> => {
+  try {
+    const response = await request;
+    const data = response.data;
+    return isJson(response) ? convertObjectToCamelCase(data) : data;
+  } catch (error) {
+    throw await convertAxiosErrorToOnfidoError(error);
   }
 };
 
@@ -49,20 +85,38 @@ export class Resource<T extends SimpleObject> {
     body?: T;
     query?: SimpleObject;
   }): Promise<any> {
-    const promise = this.axiosInstance({
+    const request = this.axiosInstance({
       method,
       url: `${this.name}/${path}`,
       data: body && convertObjectToSnakeCase(body),
       params: query && convertObjectToSnakeCase(query)
     });
 
-    try {
-      const response = await promise;
+    return handleResponse(request);
+  }
 
-      const data = response.data;
-      return isJson(response) ? convertObjectToCamelCase(data) : data;
-    } catch (error) {
-      throw convertAxiosErrorToOnfidoError(error);
-    }
+  protected async upload(body: T): Promise<any> {
+    const formData = toFormData(body);
+
+    const request = this.axiosInstance({
+      method: Method.POST,
+      url: `${this.name}/`,
+      data: formData,
+      headers: formData.getHeaders()
+    });
+
+    return handleResponse(request);
+  }
+
+  protected async download(id: string): Promise<OnfidoDownload> {
+    const request = this.axiosInstance({
+      method: Method.GET,
+      url: `${this.name}/${id}/download`,
+      responseType: "stream",
+      headers: { Accept: "*/*" }
+    });
+
+    const stream: IncomingMessage = await handleResponse(request);
+    return new OnfidoDownload(stream);
   }
 }

--- a/src/errors/OnfidoError.ts
+++ b/src/errors/OnfidoError.ts
@@ -1,5 +1,5 @@
 export class OnfidoError extends Error {
-  constructor(message: string) {
+  constructor(message?: string) {
     super(message);
     this.name = "OnfidoError";
   }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -1,3 +1,5 @@
+import FormData from "form-data";
+
 export type SimpleObject = { [key: string]: unknown };
 
 const snakeCase = (s: string): string =>
@@ -29,3 +31,10 @@ export const convertObjectToSnakeCase = (requestBody: unknown): unknown => {
 export const convertObjectToCamelCase = (
   responseBody: SimpleObject
 ): SimpleObject => deepMapObjectKeys(responseBody, camelCase);
+
+export const toFormData = (object: SimpleObject): FormData => {
+  return Object.entries(object).reduce((formData, [key, value]) => {
+    formData.append(snakeCase(key), value);
+    return formData;
+  }, new FormData());
+};

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -34,7 +34,9 @@ export const convertObjectToCamelCase = (
 
 export const toFormData = (object: SimpleObject): FormData => {
   return Object.entries(object).reduce((formData, [key, value]) => {
-    formData.append(snakeCase(key), value);
+    if (value !== undefined && value !== null) {
+      formData.append(snakeCase(key), value);
+    }
     return formData;
   }, new FormData());
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 export { Onfido, OnfidoOptions, Region } from "./Onfido";
+export { OnfidoDownload } from "./OnfidoDownload";
 
 export { Applicant, ApplicantRequest } from "./resources/Applicants";
 export { Address, AddressRequest } from "./resources/Addresses";
 export { IdNumber, IdNumberRequest } from "./resources/IdNumbers";
+export { Document, DocumentRequest } from "./resources/Documents";
 
 export { OnfidoError } from "./errors/OnfidoError";
 export { OnfidoApiError } from "./errors/OnfidoApiError";

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -1,0 +1,40 @@
+import { AxiosInstance } from "axios";
+import { ReadStream } from "fs";
+import { OnfidoDownload } from "../OnfidoDownload";
+import { Resource } from "../Resource";
+
+export type DocumentRequest = {
+  applicantId?: string | null;
+  file: ReadStream;
+  type: string;
+  side?: string | null;
+  issuingCountry?: string | null;
+};
+
+export type Document = {
+  id: string;
+  applicantId: string | null;
+  createdAt: string;
+  href: string;
+  downloadHref: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+  type: string;
+  side: string | null;
+  issuingCountry: string | null;
+};
+
+export class Documents extends Resource<DocumentRequest> {
+  constructor(axiosInstance: AxiosInstance) {
+    super("documents", axiosInstance);
+  }
+
+  public async upload(documentRequest: DocumentRequest): Promise<Document> {
+    return super.upload(documentRequest);
+  }
+
+  public async download(id: string): Promise<OnfidoDownload> {
+    return super.download(id);
+  }
+}

--- a/test/OnfidoDownload.test.ts
+++ b/test/OnfidoDownload.test.ts
@@ -1,0 +1,13 @@
+import { IncomingMessage } from "http";
+import { OnfidoDownload } from "onfido-node";
+
+const mockIncomingMessage = (contentType: string): IncomingMessage =>
+  ({ headers: { ["content-type"]: contentType } } as any);
+
+describe("contentType", () => {
+  it("gets the content type from the incoming message", () => {
+    const incomingMessage = mockIncomingMessage("image/png");
+    const download = new OnfidoDownload(incomingMessage);
+    expect(download.contentType).toBe("image/png");
+  });
+});

--- a/test/Resource.test.ts
+++ b/test/Resource.test.ts
@@ -1,0 +1,67 @@
+import axios from "axios";
+import nock from "nock";
+import { OnfidoApiError, OnfidoDownload } from "onfido-node";
+import { Resource } from "../src/Resource";
+
+const axiosInstance = axios.create({
+  baseURL: "https://api.onfido.com/v3/"
+});
+
+class TestResource extends Resource<{}> {
+  public constructor() {
+    super("test", axiosInstance);
+  }
+
+  public async upload(body: {}): Promise<any> {
+    return super.upload(body);
+  }
+
+  public async download(id: string): Promise<OnfidoDownload> {
+    return super.download(id);
+  }
+}
+
+const testResource = new TestResource();
+
+const errorJson = {
+  error: {
+    type: "the_type",
+    message: "the message",
+    fields: {
+      field: "error"
+    }
+  }
+};
+
+describe("error handling", () => {
+  it("returns an OnfidoApiError when a response is recieved", async () => {
+    expect.assertions(2);
+
+    nock("https://api.onfido.com/v3")
+      .post("/test/")
+      .reply(404, "Not Found");
+
+    try {
+      await testResource.upload({});
+    } catch (error) {
+      expect(error).toBeInstanceOf(OnfidoApiError);
+      expect(error.message).toBe("Not Found (status code 404)");
+    }
+  });
+
+  it("reads json error messages when streaming the response", async () => {
+    expect.assertions(2);
+
+    nock("https://api.onfido.com/v3")
+      .get("/test/123/download")
+      .reply(400, errorJson);
+
+    try {
+      await testResource.download("123");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OnfidoApiError);
+      const apiError = error as OnfidoApiError;
+      expect(apiError.responseBody).toEqual(errorJson);
+    }
+  });
+});

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -3,7 +3,7 @@ import {
   convertObjectToSnakeCase
 } from "../src/formatting";
 
-describe("formatRequest", () => {
+describe("convertObjectToSnakeCase", () => {
   it("converts keys to snake_case, even if nested", () => {
     expect(
       convertObjectToSnakeCase({
@@ -14,7 +14,7 @@ describe("formatRequest", () => {
   });
 });
 
-describe("formatResponse", () => {
+describe("convertObjectToCamelCase", () => {
   it("converts keys to camelCase, even if nested", () => {
     expect(
       convertObjectToCamelCase({

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -1,6 +1,7 @@
 import {
   convertObjectToCamelCase,
-  convertObjectToSnakeCase
+  convertObjectToSnakeCase,
+  toFormData
 } from "../src/formatting";
 
 describe("convertObjectToSnakeCase", () => {
@@ -22,5 +23,11 @@ describe("convertObjectToCamelCase", () => {
         a: [{ nested_in_array: 1 }]
       })
     ).toEqual({ keyName: { nestedKey: 2 }, a: [{ nestedInArray: 1 }] });
+  });
+});
+
+describe("toFormData", () => {
+  it("omits undefined and null values", () => {
+    expect(() => toFormData({ a: null, b: undefined })).not.toThrow();
   });
 });

--- a/test/resources/Documents.test.ts
+++ b/test/resources/Documents.test.ts
@@ -1,0 +1,55 @@
+import nock from "nock";
+import { Document, Onfido, OnfidoDownload } from "onfido-node";
+
+const onfido = new Onfido({ apiToken: "api_token" });
+
+const exampleDocument: Document = {
+  id: "123-abc",
+  applicantId: "applicant-123",
+  createdAt: "2020-01-01T00:00:00Z",
+  href: "https://api.onfido.com/v3/documents/123-abc",
+  downloadHref: "https://api.onfido.com/v3/documents/123-abc/downlaod",
+  fileName: "document.png",
+  fileType: "png",
+  fileSize: 500_000,
+  type: "passport",
+  side: null,
+  issuingCountry: null
+};
+
+const exampleDocumentJson = {
+  id: "123-abc",
+  applicant_id: "applicant-123",
+  created_at: "2020-01-01T00:00:00Z",
+  href: "https://api.onfido.com/v3/documents/123-abc",
+  download_href: "https://api.onfido.com/v3/documents/123-abc/downlaod",
+  file_name: "document.png",
+  file_type: "png",
+  file_size: 500_000,
+  type: "passport",
+  side: null,
+  issuing_country: null
+};
+
+it("uploads a document", async () => {
+  nock("https://api.onfido.com/v3")
+    .post("/documents/")
+    .reply(201, exampleDocumentJson);
+
+  const document = await onfido.document.upload({
+    file: "file" as any,
+    type: "passport"
+  });
+
+  expect(document).toEqual(exampleDocument);
+});
+
+it("downloads a document", async () => {
+  nock("https://api.onfido.com/v3")
+    .get("/documents/abc-123/download")
+    .reply(200, {});
+
+  const file = await onfido.document.download("abc-123");
+
+  expect(file).toBeInstanceOf(OnfidoDownload);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,7 +811,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1292,6 +1292,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
## Explanation

Add uploading and downloading functionality, and use it to add uploading and download of documents.

## Description

Downloaded files are wrapped in an `OnfidoDownload` class. This class exposes gives the content type, but I decided not to expose the file name or extension because it ended up being more complicated than I thought (extension not always present in the content-disposition header, and mapping content type to file extension would require another dependency).

Error handling gets a bit complicated for downloads:
* If we get an error response from the API which trying to download a file, the error json will be a stream rather than a string.
* Which means we have to asynchronously read the whole stream in the error handling code.
* And reading the stream of the error message could also throw an error itself.

## Testing

I've added unit tests for uploading and downloading but they're not very strong because it's difficult to check that the file data being sent/received is correct.