### PR TITLE
Add webhook event signature verification

### DIFF
--- a/src/WebhookEventVerifier.ts
+++ b/src/WebhookEventVerifier.ts
@@ -1,0 +1,54 @@
+import { OnfidoError } from "./errors/OnfidoError";
+import { convertObjectToCamelCase } from "./formatting";
+
+// Require crypto instead of importing, because Node can be built without crypto support.
+let crypto: typeof import("crypto") | undefined;
+try {
+  // tslint:disable-next-line: no-var-requires
+  crypto = require("crypto");
+} catch {
+  // We throw an error when verifying webhooks instead.
+}
+
+export type WebhookEvent = {
+  resourceType: string;
+  action: string;
+  object: {
+    id: string;
+    status: string;
+    href: string;
+    completedAtIso8601: string;
+  };
+};
+
+export class WebhookEventVerifier {
+  private readonly webhookToken: string;
+
+  constructor(webhookToken: string) {
+    this.webhookToken = webhookToken;
+  }
+
+  public readPayload(
+    rawEventBody: string | Buffer,
+    hexSignature: string
+  ): WebhookEvent {
+    if (!crypto) {
+      throw new Error("Verifying webhook events requires crypto support");
+    }
+
+    const givenSignature = Buffer.from(hexSignature, "hex");
+
+    // Compute the the actual HMAC signature from the raw request body.
+    const hmac = crypto.createHmac("sha256", this.webhookToken);
+    hmac.update(rawEventBody);
+    const eventSignature = hmac.digest();
+
+    // Use timingSafeEqual to prevent against timing attacks.
+    if (!crypto.timingSafeEqual(givenSignature, eventSignature)) {
+      throw new OnfidoError("Invalid signature for webhook event");
+    }
+
+    const { payload } = JSON.parse(rawEventBody.toString());
+    return convertObjectToCamelCase(payload) as WebhookEvent;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { Onfido, OnfidoOptions, Region } from "./Onfido";
 export { OnfidoDownload } from "./OnfidoDownload";
+export { OnfidoError } from "./errors/OnfidoError";
+export { OnfidoApiError } from "./errors/OnfidoApiError";
+export { WebhookEvent, WebhookEventVerifier } from "./WebhookEventVerifier";
 
 export { Applicant, ApplicantRequest } from "./resources/Applicants";
 export { Address, AddressRequest } from "./resources/Addresses";
@@ -11,6 +14,3 @@ export { Check, CheckRequest } from "./resources/Checks";
 export { Report } from "./resources/Reports";
 export { Webhook, WebhookRequest } from "./resources/Webhooks";
 export { SdkTokenRequest } from "./resources/SdkTokens";
-
-export { OnfidoError } from "./errors/OnfidoError";
-export { OnfidoApiError } from "./errors/OnfidoApiError";

--- a/test/WebhookEventVerifier.test.ts
+++ b/test/WebhookEventVerifier.test.ts
@@ -1,0 +1,42 @@
+import { OnfidoError, WebhookEvent, WebhookEventVerifier } from "onfido-node";
+
+const webhookToken = "_ABC123abc123ABC123abc123ABC123_";
+const verifier = new WebhookEventVerifier(webhookToken);
+
+const rawEvent = `{"payload":{"resource_type":"check","action":"check.completed","object":{"id":"check-123","status":"complete","completed_at_iso8601":"2020-01-01T00:00:00Z","href":"https://api.onfido.com/v3/checks/check-123"}}}`;
+
+const expectedEvent: WebhookEvent = {
+  action: "check.completed",
+  resourceType: "check",
+  object: {
+    id: "check-123",
+    href: "https://api.onfido.com/v3/checks/check-123",
+    status: "complete",
+    completedAtIso8601: "2020-01-01T00:00:00Z"
+  }
+};
+
+it("returns the payload if the signature is valid", () => {
+  const signature =
+    "a0082d7481f9f0a2907583dbe1f344d6d4c0d9989df2fd804f98479f60cd760e";
+
+  const event = verifier.readPayload(rawEvent, signature);
+
+  expect(event).toEqual(expectedEvent);
+});
+
+it("allows passing the body as a buffer", () => {
+  const signature =
+    "a0082d7481f9f0a2907583dbe1f344d6d4c0d9989df2fd804f98479f60cd760e";
+
+  const event = verifier.readPayload(Buffer.from(rawEvent), signature);
+
+  expect(event).toEqual(expectedEvent);
+});
+
+it("throws an error if the signature is invalid", () => {
+  const signature =
+    "b0082d7481f9f0a2907583dbe1f344d6d4c0d9989df2fd804f98479f60cd760e";
+
+  expect(() => verifier.readPayload(rawEvent, signature)).toThrow(OnfidoError);
+});


### PR DESCRIPTION
## Explanation

Add functionality for verifying webhook events.

## Description

I'm using a class initialised with the webhook token which then allows checking events given the raw request body (can't be parsed from json first) and the signature.

I haven't added any examples to the readme or anything because I think that should all go in the api docs.

## Testing

Unit tests and manually testing with actual data.