### PR TITLE
Document the format of responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,63 @@ onfido.applicant
   });
 ```
 
+## Response format
+
+Most responses will be normal JavaScript objects. Property names will be in camelCase rather than snake_case, including property names in nested objects.
+
+```js
+const applicant = await onfido.applicant.create({
+  firstName: "Jane",
+  lastName: "Doe",
+  address: {
+    flatNumber: "12",
+    postcode: "S2 2DF",
+    country: "GBR",
+  }
+});
+
+console.log(applicant);
+{
+  id: "<APPLICANT_ID>",
+  createdAt: "2020-01-22T10:44:01Z",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: null,
+  dob: null,
+  deleteAt: null,
+  href: "/v3/applicants/<APPLICANT_ID>",
+  address: {
+    flatNumber: "12",
+    buildingNumber: null,
+    buildingName: null,
+    street: null,
+    subStreet: null,
+    town: null,
+    state: null,
+    postcode: "S2 2DF",
+    country: "GBR",
+    line1: null,
+    line2: null,
+    line3: null
+  },
+  idNumbers: []
+}
+```
+
+File downloads, for example `onfido.document.download(documentId)`, will return instances of `OnfidoDownload`.
+
+These objects will have a content type, e.g. `image/png`.
+
+```js
+download.contentType;
+```
+
+Call `asStream()` to get a `Readable` stream of the download. You can read more about [`Readable` streams](https://nodejs.org/api/stream.html#stream_readable_streams).
+
+```js
+const readableStream = download.asStream();
+```
+
 ## More Documentation
 
 More documentation and code examples can be found at <https://documentation.onfido.com>

--- a/src/Onfido.ts
+++ b/src/Onfido.ts
@@ -46,6 +46,10 @@ export class Onfido {
     timeout = 30_000,
     unknownApiUrl
   }: OnfidoOptions) {
+    if (!apiToken) {
+      throw new Error("No apiToken provided");
+    }
+
     const regionUrl = apiUrls[region];
     if (!regionUrl) {
       throw new Error("Unknown region " + region);

--- a/src/OnfidoDownload.ts
+++ b/src/OnfidoDownload.ts
@@ -8,7 +8,7 @@ export class OnfidoDownload {
     this.incomingMessage = incomingMessage;
   }
 
-  public asReadStream(): Readable {
+  public asStream(): Readable {
     // Use a PassThrough stream so the IncomingMessage isn't exposed.
     const passThroughStream = new PassThrough();
     this.incomingMessage.pipe(passThroughStream);

--- a/test/Onfido.test.ts
+++ b/test/Onfido.test.ts
@@ -27,6 +27,11 @@ it("throws an error for unknown regions", () => {
   );
 });
 
+it("throws an error if no api token is provided", () => {
+  expect(() => new Onfido({ apiToken: "" } as any)).toThrow("apiToken");
+  expect(() => new Onfido({ wrongName: "token" } as any)).toThrow("apiToken");
+});
+
 it("allows changing the default timeout", () => {
   const onfido = new Onfido({ apiToken: "token", timeout: 123 });
   expect(onfido.axiosInstance.defaults.timeout).toBe(123);


### PR DESCRIPTION
I realised that it wouldn't be obvious to users that the property/key names in response objects are in camelCase rather than the snake_case of the API, and it's not something that would be obvious from code examples (once we add them to the main api docs), so I've added it to the readme.

Also a couple of other very minor code changes
