### PR TITLE
Make filepath required when specifying contents

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -5,7 +5,7 @@ export type SimpleObject = { [key: string]: unknown };
 
 type ContentsAndOptions = {
   contents: Readable;
-  filepath?: string;
+  filepath: string;
   contentType?: string;
 };
 


### PR DESCRIPTION
A tiny update for #18 (unreleased), to make `filepath` required when specifying the contents explicitly.