### PR TITLE
Fix type declaration location when importing JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/api",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Node.js library for the Onfido API",
   "keywords": [
     "onfido",

--- a/src/ignoreJson.d.ts
+++ b/src/ignoreJson.d.ts
@@ -1,0 +1,2 @@
+// Using resolveJsonModule with TypeScript and importing package.json causes issues because it causes rootDir to change to . instead of ./src, which means generated type declarations get output in dist/src rather than just dist. Since rollup inserts JSON directly we can just ignore JSON modules in TypeScript.
+declare module "*.json";

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./**/*"],
   "compilerOptions": {
     "baseUrl": "../",
+    "resolveJsonModule": true,
     "paths": {
       "onfido-node": ["src/index"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "declaration": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "rootDir": "src"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
 Using `resolveJsonModule` with TypeScript and importing `../package.json` caused type declarations to be generated under `dist/src` rather than just `dist`. This is because importing something from the root directory changed rootDir to `.` instead of `src`. Since rollup inserts JSON directly we can just ignore JSON modules in TypeScript and let rollup handle it.

Fixes #26

See https://stackoverflow.com/questions/52121725/maintain-src-folder-structure-when-building-to-dist-folder-with-typescript-3 and https://github.com/microsoft/TypeScript/issues/24715 for more info.