### PR TITLE
Additional changes to v3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ For TypeScript users, types are available as well:
 import { Onfido, Region, Applicant, OnfidoApiError } from "@onfido/api";
 ```
 
-Configure with your API token, and region if necessary:
+Configure with your API token and region:
 
 ```js
 const onfido = new Onfido({
-  apiToken: process.env.ONFIDO_API_TOKEN
-  // Defaults to Region.EU (api.onfido.com), supports Region.US and Region.CA
-  // region: Region.US
+  apiToken: process.env.ONFIDO_API_TOKEN,
+  // Supports Region.EU, Region.US and Region.CA
+  region: Region.EU
 });
 ```
 

--- a/src/Onfido.ts
+++ b/src/Onfido.ts
@@ -49,7 +49,11 @@ export class Onfido {
       throw new Error("No apiToken provided");
     }
     if (!region || !Object.values(Region).includes(region)) {
-      throw new Error(`Unknown region '${region}'`);
+      throw new Error(
+        `Unknown or missing region '${region}'. ` +
+          "We previously defaulted to region 'EU', so if you previously didn’t " +
+          "set a region or used api.onfido.com, please set your region to 'EU'"
+      );
     }
 
     const regionUrl = `https://api.${region.toLowerCase()}.onfido.com/v3.1/`;

--- a/src/Onfido.ts
+++ b/src/Onfido.ts
@@ -19,15 +19,9 @@ export enum Region {
 
 export type OnfidoOptions = {
   apiToken: string;
-  region?: Region;
+  region: Region;
   timeout?: number;
   unknownApiUrl?: string;
-};
-
-const apiUrls = {
-  [Region.EU]: "https://api.onfido.com/v3.1/",
-  [Region.US]: "https://api.us.onfido.com/v3.1/",
-  [Region.CA]: "https://api.ca.onfido.com/v3.1/"
 };
 
 export class Onfido {
@@ -47,18 +41,18 @@ export class Onfido {
 
   constructor({
     apiToken,
-    region = Region.EU,
+    region,
     timeout = 30_000,
     unknownApiUrl
   }: OnfidoOptions) {
     if (!apiToken) {
       throw new Error("No apiToken provided");
     }
-
-    const regionUrl = apiUrls[region];
-    if (!regionUrl) {
-      throw new Error("Unknown region " + region);
+    if (!region || !Object.values(Region).includes(region)) {
+      throw new Error(`Unknown region '${region}'`);
     }
+
+    const regionUrl = `https://api.${region.toLowerCase()}.onfido.com/v3.1/`;
 
     this.axiosInstance = axios.create({
       baseURL: unknownApiUrl || regionUrl,

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -15,11 +15,13 @@ type ContentsAndOptions = {
 
 export type FileLike = Readable | ContentsAndOptions;
 
-const snakeCase = (s: string): string =>
-  s.replace(/[A-Z]/g, char => `_${char.toLowerCase()}`);
+const snakeCase = (camelCaseString: string): string =>
+  camelCaseString.replace(/[A-Z]/g, char => `_${char.toLowerCase()}`);
 
-const camelCase = (s: string): string =>
-  s.replace(/_[a-z]/g, underscoreChar => underscoreChar[1].toUpperCase());
+const camelCase = (snakeCaseString: string): string =>
+  snakeCaseString
+    .replace(/_[0-9]/g, underscoreDigit => underscoreDigit[1])
+    .replace(/_[a-z]/g, underscoreChar => underscoreChar[1].toUpperCase());
 
 const deepMapObjectKeys = (value: unknown, f: (key: string) => string): any => {
   if (!(value instanceof Object)) {

--- a/test/Onfido.test.ts
+++ b/test/Onfido.test.ts
@@ -37,13 +37,13 @@ it("allows setting the CA region", () => {
 
 it("throws an error for no region", () => {
   expect(() => new Onfido({ apiToken: "token" } as any)).toThrow(
-    "Unknown region 'undefined'"
+    "Unknown or missing region 'undefined'"
   );
 });
 
 it("throws an error for unknown regions", () => {
   expect(() => new Onfido({ apiToken: "token", region: "abc" as any })).toThrow(
-    "Unknown region 'abc'"
+    "Unknown or missing region 'abc'"
   );
 });
 

--- a/test/Onfido.test.ts
+++ b/test/Onfido.test.ts
@@ -1,23 +1,23 @@
 import { Onfido, Region } from "onfido-node";
 
 it("sets the authorization header from the given token", () => {
-  const onfido = new Onfido({ apiToken: "api_token" });
+  const onfido = new Onfido({ apiToken: "api_token", region: Region.EU });
   expect(onfido.axiosInstance.defaults.headers.Authorization).toBe(
     "Token token=api_token"
   );
 });
 
 it("contains a user agent header", () => {
-  const onfido = new Onfido({ apiToken: "api_token" });
+  const onfido = new Onfido({ apiToken: "api_token", region: Region.EU });
   expect(onfido.axiosInstance.defaults.headers["User-Agent"]).toMatch(
     /^onfido-node\/\d+\.\d+\.\d+$/
   );
 });
 
-it("defaults to the EU region", () => {
-  const onfido = new Onfido({ apiToken: "token" });
+it("allows setting the EU region", () => {
+  const onfido = new Onfido({ apiToken: "token", region: Region.EU });
   expect(onfido.axiosInstance.defaults.baseURL).toBe(
-    "https://api.onfido.com/v3.1/"
+    "https://api.eu.onfido.com/v3.1/"
   );
 });
 
@@ -35,9 +35,15 @@ it("allows setting the CA region", () => {
   );
 });
 
+it("throws an error for no region", () => {
+  expect(() => new Onfido({ apiToken: "token" } as any)).toThrow(
+    "Unknown region 'undefined'"
+  );
+});
+
 it("throws an error for unknown regions", () => {
   expect(() => new Onfido({ apiToken: "token", region: "abc" as any })).toThrow(
-    "Unknown region abc"
+    "Unknown region 'abc'"
   );
 });
 
@@ -47,6 +53,11 @@ it("throws an error if no api token is provided", () => {
 });
 
 it("allows changing the default timeout", () => {
-  const onfido = new Onfido({ apiToken: "token", timeout: 123 });
+  const onfido = new Onfido({
+    apiToken: "token",
+    region: Region.EU,
+    timeout: 123
+  });
+
   expect(onfido.axiosInstance.defaults.timeout).toBe(123);
 });

--- a/test/Resource.test.ts
+++ b/test/Resource.test.ts
@@ -1,15 +1,10 @@
-import axios from "axios";
-import nock from "nock";
 import { OnfidoApiError, OnfidoDownload } from "onfido-node";
 import { Resource } from "../src/Resource";
-
-const axiosInstance = axios.create({
-  baseURL: "https://api.onfido.com/v3.1/"
-});
+import { createNock, onfido } from "./testHelpers";
 
 class TestResource extends Resource<{}> {
   public constructor() {
-    super("test", axiosInstance);
+    super("test", onfido.axiosInstance);
   }
 
   public async upload(body: {}): Promise<any> {
@@ -37,7 +32,7 @@ describe("error handling", () => {
   it("returns an OnfidoApiError when a response is recieved", async () => {
     expect.assertions(2);
 
-    nock("https://api.onfido.com/v3.1")
+    createNock()
       .post("/test/")
       .reply(404, "Not Found");
 
@@ -52,7 +47,7 @@ describe("error handling", () => {
   it("reads json error messages when streaming the response", async () => {
     expect.assertions(2);
 
-    nock("https://api.onfido.com/v3.1")
+    createNock()
       .get("/test/123/download")
       .reply(400, errorJson);
 

--- a/test/formatting.test.ts
+++ b/test/formatting.test.ts
@@ -20,9 +20,9 @@ describe("convertObjectToCamelCase", () => {
     expect(
       convertObjectToCamelCase({
         key_name: { nested_key: 2 },
-        a: [{ nested_in_array: 1 }]
+        a: [{ nested_in_array_1: 1 }]
       })
-    ).toEqual({ keyName: { nestedKey: 2 }, a: [{ nestedInArray: 1 }] });
+    ).toEqual({ keyName: { nestedKey: 2 }, a: [{ nestedInArray1: 1 }] });
   });
 });
 

--- a/test/resources/Addresses.test.ts
+++ b/test/resources/Addresses.test.ts
@@ -1,7 +1,5 @@
-import nock from "nock";
-import { Address, Onfido } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { Address } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleAddress: Address = {
   postcode: "S2 2DF",
@@ -34,7 +32,7 @@ const exampleAddressJson = {
 };
 
 it("allows picking addresses", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/addresses/pick")
     .query({ postcode: "S2 2DF" })
     .reply(200, { addresses: [exampleAddressJson, exampleAddressJson] });

--- a/test/resources/Applicants.test.ts
+++ b/test/resources/Applicants.test.ts
@@ -1,7 +1,5 @@
-import nock from "nock";
-import { Applicant, Onfido } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { Applicant } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleApplicant: Applicant = {
   id: "123-abc",
@@ -56,7 +54,7 @@ const exampleApplicantJson = {
 };
 
 it("creates applicants", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/applicants/", {
       first_name: "Test",
       last_name: "Applicant",
@@ -80,7 +78,7 @@ it("creates applicants", async () => {
 });
 
 it("finds an applicant", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/applicants/123-abc")
     .reply(200, exampleApplicantJson);
 
@@ -90,7 +88,7 @@ it("finds an applicant", async () => {
 });
 
 it("updates an applicant", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .put("/applicants/123-abc", { first_name: "Test2" })
     .reply(200, exampleApplicantJson);
 
@@ -102,7 +100,7 @@ it("updates an applicant", async () => {
 });
 
 it("deletes an applicant", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .delete("/applicants/123-abc")
     .reply(204);
 
@@ -110,7 +108,7 @@ it("deletes an applicant", async () => {
 });
 
 it("restores an applicant", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/applicants/123-abc/restore")
     .reply(204);
 
@@ -118,7 +116,7 @@ it("restores an applicant", async () => {
 });
 
 it("lists applicants", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/applicants/")
     .query({
       page: 1,

--- a/test/resources/Autofill.test.ts
+++ b/test/resources/Autofill.test.ts
@@ -16,7 +16,9 @@ const exampleAutofillJson = {
     last_name: "MAVARINE",
     mrz_line1: "IDFRAMAVARINE<<<<<<<<<<<<<<<<<075123",
     mrz_line2: "2000000000000AMANDINE<CHANT9007219F5",
-    nationality: "FRA"
+    nationality: "FRA",
+    address_line_1: "address 1",
+    address_line_2: "address 2"
   }
 };
 
@@ -35,7 +37,9 @@ const exampleAutofillResult = {
     lastName: "MAVARINE",
     mrzLine1: "IDFRAMAVARINE<<<<<<<<<<<<<<<<<075123",
     mrzLine2: "2000000000000AMANDINE<CHANT9007219F5",
-    nationality: "FRA"
+    nationality: "FRA",
+    addressLine1: "address 1",
+    addressLine2: "address 2"
   }
 };
 

--- a/test/resources/Autofill.test.ts
+++ b/test/resources/Autofill.test.ts
@@ -1,7 +1,4 @@
-import nock from "nock";
-import { Onfido } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { createNock, onfido } from "../testHelpers";
 
 // Fake data, taken from documentation.
 const exampleAutofillJson = {
@@ -43,7 +40,7 @@ const exampleAutofillResult = {
 };
 
 it("performs autofill", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/extractions/", {
       document_id: "21345-xxx"
     })

--- a/test/resources/Checks.test.ts
+++ b/test/resources/Checks.test.ts
@@ -1,7 +1,5 @@
-import nock from "nock";
-import { Check, Onfido, OnfidoDownload } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { Check, OnfidoDownload } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleCheck: Check = {
   id: "abc-123",
@@ -38,7 +36,7 @@ const exampleCheckJson = {
 };
 
 it("creates a check", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/checks/", {
       applicant_id: "applicant-123",
       report_names: ["document", "identity_enhanced"],
@@ -60,7 +58,7 @@ it("creates a check", async () => {
 });
 
 it("finds a check", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/checks/123-abc")
     .reply(200, exampleCheckJson);
 
@@ -70,7 +68,7 @@ it("finds a check", async () => {
 });
 
 it("lists checks", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/checks/")
     .query({ applicant_id: "applicant-123" })
     .reply(200, { checks: [exampleCheckJson, exampleCheckJson] });
@@ -81,7 +79,7 @@ it("lists checks", async () => {
 });
 
 it("resumes a check", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/checks/abc-123/resume")
     .reply(204);
 
@@ -89,7 +87,7 @@ it("resumes a check", async () => {
 });
 
 it("downloads a check", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/checks/abc-123/download")
     .reply(200, {});
 

--- a/test/resources/Documents.test.ts
+++ b/test/resources/Documents.test.ts
@@ -1,8 +1,6 @@
 import { ReadStream } from "fs";
-import nock from "nock";
-import { Document, Onfido, OnfidoDownload } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { Document, OnfidoDownload } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleDocument: Document = {
   id: "123-abc",
@@ -33,7 +31,7 @@ const exampleDocumentJson = {
 };
 
 it("uploads a document", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/documents/")
     .reply(201, exampleDocumentJson);
 
@@ -46,7 +44,7 @@ it("uploads a document", async () => {
 });
 
 it("downloads a document", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/documents/abc-123/download")
     .reply(200, {});
 
@@ -56,7 +54,7 @@ it("downloads a document", async () => {
 });
 
 it("finds a document", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/documents/123-abc")
     .reply(200, exampleDocumentJson);
 
@@ -66,7 +64,7 @@ it("finds a document", async () => {
 });
 
 it("lists documents", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/documents/")
     .query({ applicant_id: "applicant-123" })
     .reply(200, { documents: [exampleDocumentJson, exampleDocumentJson] });

--- a/test/resources/LivePhotos.test.ts
+++ b/test/resources/LivePhotos.test.ts
@@ -1,8 +1,7 @@
-import nock from "nock";
-import { LivePhoto, Onfido, OnfidoDownload } from "onfido-node";
+import { LivePhoto, OnfidoDownload } from "onfido-node";
 import { PassThrough } from "stream";
 
-const onfido = new Onfido({ apiToken: "api_token" });
+import { createNock, onfido } from "../testHelpers";
 
 const exampleLivePhoto: LivePhoto = {
   id: "123-abc",
@@ -25,7 +24,7 @@ const exampleLivePhotoJson = {
 };
 
 it("uploads a live photo", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/live_photos/")
     .reply(201, exampleLivePhotoJson);
 
@@ -46,7 +45,7 @@ it("uploads a live photo", async () => {
 });
 
 it("downloads a live photo", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_photos/abc-123/download")
     .reply(200, {});
 
@@ -56,7 +55,7 @@ it("downloads a live photo", async () => {
 });
 
 it("finds a live photo", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_photos/123-abc")
     .reply(200, exampleLivePhotoJson);
 
@@ -66,7 +65,7 @@ it("finds a live photo", async () => {
 });
 
 it("lists live photos", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_photos/")
     .query({ applicant_id: "applicant-123" })
     .reply(200, { live_photos: [exampleLivePhotoJson, exampleLivePhotoJson] });

--- a/test/resources/LiveVideos.test.ts
+++ b/test/resources/LiveVideos.test.ts
@@ -1,7 +1,5 @@
-import nock from "nock";
-import { LiveVideo, Onfido, OnfidoDownload } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { LiveVideo, OnfidoDownload } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleLiveVideo: LiveVideo = {
   id: "123-abc",
@@ -24,7 +22,7 @@ const exampleLiveVideoJson = {
 };
 
 it("downloads a live video", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_videos/abc-123/download")
     .reply(200, {});
 
@@ -34,7 +32,7 @@ it("downloads a live video", async () => {
 });
 
 it("downloads a live video frame", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_videos/abc-123/frame")
     .reply(200, {});
 
@@ -44,7 +42,7 @@ it("downloads a live video frame", async () => {
 });
 
 it("finds a live video", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_videos/123-abc")
     .reply(200, exampleLiveVideoJson);
 
@@ -54,7 +52,7 @@ it("finds a live video", async () => {
 });
 
 it("lists live videos", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/live_videos/")
     .query({ applicant_id: "applicant-123" })
     .reply(200, { live_videos: [exampleLiveVideoJson, exampleLiveVideoJson] });

--- a/test/resources/Reports.test.ts
+++ b/test/resources/Reports.test.ts
@@ -1,7 +1,5 @@
-import nock from "nock";
-import { Onfido, Report } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { Report } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleReport: Report = {
   id: "abc-123",
@@ -32,7 +30,7 @@ const exampleReportJson = {
 };
 
 it("finds a report", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/reports/123-abc")
     .reply(200, exampleReportJson);
 
@@ -42,7 +40,7 @@ it("finds a report", async () => {
 });
 
 it("lists reports", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/reports/")
     .query({ check_id: "check-123" })
     .reply(200, { reports: [exampleReportJson, exampleReportJson] });
@@ -53,7 +51,7 @@ it("lists reports", async () => {
 });
 
 it("resumes a report", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/reports/abc-123/resume")
     .reply(204);
 
@@ -61,7 +59,7 @@ it("resumes a report", async () => {
 });
 
 it("cancels a report", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/reports/abc-123/cancel")
     .reply(204);
 

--- a/test/resources/SdkTokens.test.ts
+++ b/test/resources/SdkTokens.test.ts
@@ -1,10 +1,7 @@
-import nock from "nock";
-import { Onfido } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { createNock, onfido } from "../testHelpers";
 
 it("generates an sdk token", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/sdk_token/", {
       applicant_id: "applicant-123",
       referrer: "https://*.example.com/*"

--- a/test/resources/Webhooks.test.ts
+++ b/test/resources/Webhooks.test.ts
@@ -1,7 +1,5 @@
-import nock from "nock";
-import { Onfido, Webhook } from "onfido-node";
-
-const onfido = new Onfido({ apiToken: "api_token" });
+import { Webhook } from "onfido-node";
+import { createNock, onfido } from "../testHelpers";
 
 const exampleWebhook: Webhook = {
   id: "abc-123",
@@ -16,7 +14,7 @@ const exampleWebhook: Webhook = {
 const exampleWebhookJson = exampleWebhook;
 
 it("creates a webhook", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .post("/webhooks/", { url: "https://example.com" })
     .reply(201, exampleWebhookJson);
 
@@ -28,7 +26,7 @@ it("creates a webhook", async () => {
 });
 
 it("finds a webhook", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/webhooks/123-abc")
     .reply(200, exampleWebhookJson);
 
@@ -38,7 +36,7 @@ it("finds a webhook", async () => {
 });
 
 it("updates a webhook", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .put("/webhooks/123-abc", { enabled: false })
     .reply(200, exampleWebhookJson);
 
@@ -50,7 +48,7 @@ it("updates a webhook", async () => {
 });
 
 it("deletes a webhook", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .delete("/webhooks/123-abc")
     .reply(204);
 
@@ -58,7 +56,7 @@ it("deletes a webhook", async () => {
 });
 
 it("lists webhooks", async () => {
-  nock("https://api.onfido.com/v3.1")
+  createNock()
     .get("/webhooks/")
     .reply(200, { webhooks: [exampleWebhookJson, exampleWebhookJson] });
 

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,0 +1,7 @@
+import nock from "nock";
+import { Onfido, Region } from "onfido-node";
+
+export const onfido = new Onfido({ region: Region.EU, apiToken: "api_token" });
+
+export const createNock = (): nock.Scope =>
+  nock("https://api.eu.onfido.com/v3.1");

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./**/*"],
   "compilerOptions": {
     "baseUrl": "../",
+    "rootDir": "../",
     "resolveJsonModule": true,
     "paths": {
       "onfido-node": ["src/index"]


### PR DESCRIPTION
This branch targets the current v3.1 branch, I just put them in a separate branch to get them reviewed.

Two commits:
* Make region required, use api.eu.onfido.com (using api.eu.onfido.com may not happen, TBC)
* Convert `address_line_1` etc in autofill responses to `addressLine1` rather than `addressLine_1`