### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,13 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 'release/**'
 
 jobs:
   build:
@@ -16,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,4 +31,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - name: Mock testing
+      run: npm test
+    - name: E2E testing
+      run: npm test test/resources/Applicants.test.ts
+      env:
+        ONFIDO_API_TOKEN: ${{secrets.ONFIDO_API_TOKEN}}
+        NOCK_OFF: true


### PR DESCRIPTION
- Enable E2E tests (applicant tests only for the time being)
- Update node.js supported versions
- Run CI on `release/*` branches as well