### PR TITLE
Fix bug when uploading documents validateImageQuality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7.1, 30 May 2023
+
+- Fix bug when uploading documents with `validateImageQuality`.
+
 ## v2.7.0, 24 January 2023
 
 - Updated to use API v3.6. For more details please see our [release notes](https://developers.onfido.com/release-notes#api-v36)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/api",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Node.js library for the Onfido API",
   "keywords": [
     "onfido",

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -18,6 +18,14 @@ export type FileLike = Readable | ContentsAndOptions;
 const snakeCase = (camelCaseString: string): string =>
   camelCaseString.replace(/[A-Z]/g, char => `_${char.toLowerCase()}`);
 
+const formatValue = (value: any): string => {
+  if (typeof value === 'boolean') {
+    return String(value);
+  } else {
+    return value;
+  }
+};
+
 const camelCase = (snakeCaseString: string): string =>
   snakeCaseString
     .replace(/_[0-9]/g, underscoreDigit => underscoreDigit[1])
@@ -58,7 +66,7 @@ export const toFormData = (object: SimpleObject): IFormData => {
           formData.append(snakeCase(key + "[" + elementKey + "]"), elementValue);
         }
       } else {
-        formData.append(snakeCase(key), value);
+        formData.append(snakeCase(key), formatValue(value));
       }
     }
     return formData;

--- a/src/resources/Documents.ts
+++ b/src/resources/Documents.ts
@@ -10,7 +10,7 @@ export type DocumentRequest = {
   type: string;
   side?: string | null;
   issuingCountry?: string | null;
-  validateImageQuality?: boolean | null;
+  validateImageQuality?: boolean | null | string;
   location?: LocationRequest | null;
 };
 


### PR DESCRIPTION
When uploading a document and using the `validateImageQuality` flag, the client should pass it as a `String` instead of a `Boolean`.