### PR TITLE
Add signed evidence file download endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8.0 24 November 2023
+
+- Added `signed_evidence_file` method for WorkflowRuns
+
 ## v2.7.2, 14 June 2023
 
 - Added `sandbox` field to Check.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/api",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Node.js library for the Onfido API",
   "keywords": [
     "onfido",

--- a/src/resources/WorkflowRuns.ts
+++ b/src/resources/WorkflowRuns.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance } from "axios";
+import { OnfidoDownload } from "../OnfidoDownload";
 import { Method, Resource } from "../Resource";
 
 export type WorkflowRunRequest = {
@@ -8,15 +9,15 @@ export type WorkflowRunRequest = {
 };
 
 type WorkflowRunError = {
-  type:	string;
+  type: string;
   message: string;
 }
 
 type WorkflowRunLink = {
-  url:	string;
-  completed_redirect_url:	string;
-  expired_redirect_url:	string;
-  expires_at:	string;
+  url: string;
+  completed_redirect_url: string;
+  expired_redirect_url: string;
+  expires_at: string;
   language: string;
 }
 
@@ -62,5 +63,9 @@ export class WorkflowRuns extends Resource<WorkflowRunRequest> {
     });
 
     return workflowRuns;
+  }
+
+  public async evidence(id: string): Promise<OnfidoDownload> {
+    return super.download(`${id}/signed_evidence_file`);
   }
 }

--- a/test/resources/WorkflowRuns.test.ts
+++ b/test/resources/WorkflowRuns.test.ts
@@ -1,4 +1,4 @@
-import { Applicant, WorkflowRun } from "onfido-node";
+import { Applicant, WorkflowRun, OnfidoDownload } from "onfido-node";
 
 import { exampleWorkflowRun } from "../testExamples";
 import {
@@ -78,4 +78,16 @@ it("lists workflow runs", async () => {
       getExpectedWorkflowRun(exampleWorkflowRun)
     ])
   );
+});
+
+it("downloads a signed evidence file", async () => {
+  const workflowRun = await createWorkflowRun(applicant, workflow_id);
+
+  createNock()
+    .get("/workflow_runs/" + workflowRun.id + "/signed_evidence_file")
+    .reply(200, {});
+
+  const file = await onfido.workflowRun.evidence(workflowRun.id);
+
+  expect(file).toBeInstanceOf(OnfidoDownload);
 });


### PR DESCRIPTION
This adds [signed pdf download](https://documentation.onfido.com/#retrieve-workflow-run-signed-evidence-file) endpoint.