### PR TITLE
test: add tests for Task

### DIFF
--- a/test/resources/tasks.test.ts
+++ b/test/resources/tasks.test.ts
@@ -1,0 +1,65 @@
+import { Applicant, Task } from "onfido-node";
+
+import { exampleTask } from "../test-examples";
+import {
+  cleanUpApplicants,
+  cleanUpWebhooks,
+  createApplicant,
+  completeTask,
+  createWorkflowRun,
+  getExpectedObject,
+  onfido
+} from "../test-helpers";
+
+function getExpectedTask(exampleTask: Task, overrideProperties = {}) {
+  return getExpectedObject(exampleTask, {
+    task_def_id: expect.stringMatching(/^[0-9a-z-_]+$/),
+    task_def_version: null,
+    workflow_run_id: expect.stringMatching(/^[0-9a-z-]+$/),
+    created_at: expect.anything(),
+    updated_at: expect.anything(),
+    ...overrideProperties,
+  });
+}
+
+const workflow_id = "e8c921eb-0495-44fe-b655-bcdcaffdafe5";
+let applicant: Applicant;
+let workflowRunId: string;
+
+beforeEach(async () => {
+  applicant = (await createApplicant()).data;
+  workflowRunId = (await createWorkflowRun(applicant, workflow_id)).data.id;
+});
+
+afterAll(() => {
+  return Promise.all([cleanUpApplicants(), cleanUpWebhooks()]);
+});
+
+it("lists tasks", async () => {
+  const tasks = await onfido.listTasks(workflowRunId);
+
+  expect(tasks.data).toEqual([
+    getExpectedTask(exampleTask),
+    getExpectedTask(exampleTask)
+  ]);
+});
+
+it("finds a task", async () => {
+  const taskId = (await onfido.listTasks(workflowRunId)).data[0].id;
+
+  const task = await onfido.retrieveTask(workflowRunId, taskId);
+
+  expect(task.data).toEqual(
+    getExpectedTask(exampleTask, { input: expect.anything(), output: null })
+  );
+});
+
+it("completes a task", async () => {
+  const taskId = (await onfido.listTasks(workflowRunId)).data.filter(
+    (task) => task.id !== "start"
+  )[0].id;
+
+  const completedTask = await completeTask(workflowRunId, taskId);
+  expect(completedTask.status).toEqual(200);
+  expect(completedTask.data).toEqual({});
+});

--- a/test/resources/tasks.test.ts
+++ b/test/resources/tasks.test.ts
@@ -32,7 +32,7 @@ beforeEach(async () => {
 });
 
 afterAll(() => {
-  return Promise.all([cleanUpApplicants(), cleanUpWebhooks()]);
+  return Promise.all([cleanUpApplicants()]);
 });
 
 it("lists tasks", async () => {

--- a/test/resources/tasks.test.ts
+++ b/test/resources/tasks.test.ts
@@ -18,7 +18,7 @@ function getExpectedTask(exampleTask: Task, overrideProperties = {}) {
     workflow_run_id: expect.stringMatching(/^[0-9a-z-]+$/),
     created_at: expect.anything(),
     updated_at: expect.anything(),
-    ...overrideProperties,
+    ...overrideProperties
   });
 }
 
@@ -56,7 +56,7 @@ it("finds a task", async () => {
 
 it("completes a task", async () => {
   const taskId = (await onfido.listTasks(workflowRunId)).data.filter(
-    (task) => task.id !== "start"
+    task => task.id !== "start"
   )[0].id;
 
   const completedTask = await completeTask(workflowRunId, taskId);

--- a/test/test-examples.ts
+++ b/test/test-examples.ts
@@ -1,4 +1,11 @@
-import { Applicant, Check, Document, Webhook, WorkflowRun } from "onfido-node";
+import {
+  Applicant,
+  Check,
+  Document,
+  Task,
+  Webhook,
+  WorkflowRun
+} from "onfido-node";
 
 export const exampleApplicant: Applicant = {
   id: "123-abc",
@@ -88,4 +95,11 @@ export const exampleWorkflowRun: WorkflowRun = {
   created_at: "2022-06-28T15:39:42Z",
   updated_at: "2022-06-28T15:39:42Z",
   tags: []
+};
+
+export const exampleTask: Task = {
+  id: "abc-123",
+  task_def_id: "task_123",
+  created_at: "2022-06-28T15:39:42Z",
+  updated_at: "2022-07-28T15:40:42Z",
 };

--- a/test/test-examples.ts
+++ b/test/test-examples.ts
@@ -101,5 +101,5 @@ export const exampleTask: Task = {
   id: "abc-123",
   task_def_id: "task_123",
   created_at: "2022-06-28T15:39:42Z",
-  updated_at: "2022-07-28T15:40:42Z",
+  updated_at: "2022-07-28T15:40:42Z"
 };

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -9,8 +9,7 @@ import {
   MotionCapture,
   Configuration,
   DefaultApi,
-  Report,
-  Region
+  Report
 } from "onfido-node";
 
 export const onfido = new DefaultApi(
@@ -26,7 +25,7 @@ export function getExpectedObject(exampleObject: any, overrideProperties = {}) {
   var expectedObject = { ...exampleObject, ...overrideProperties };
 
   if ("id" in expectedObject)
-    expectedObject.id = expect.stringMatching(/^[0-9a-z-]+$/);
+    expectedObject.id = expect.stringMatching(/^[0-9a-z-_]+$/);
 
   if ("href" in expectedObject)
     expectedObject.href = expect.stringMatching(/^\/v3.6\/.+$/);
@@ -175,4 +174,19 @@ export function createWorkflowRun(applicant: Applicant, workflow_id: string) {
     applicant_id: applicant.id,
     workflow_id: workflow_id
   });
+}
+
+export function completeTask(
+  workflowRunId: string,
+  taskId: string,
+  overrideProperties = {}
+) {
+  const taskData = {
+    data: {
+      first_name: "Test",
+      last_name: "Applicant",
+      ...overrideProperties,
+    },
+  };
+  return onfido.completeTask(workflowRunId, taskId, taskData);
 }

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -185,8 +185,8 @@ export function completeTask(
     data: {
       first_name: "Test",
       last_name: "Applicant",
-      ...overrideProperties,
-    },
+      ...overrideProperties
+    }
   };
   return onfido.completeTask(workflowRunId, taskId, taskData);
 }


### PR DESCRIPTION
Add tests for `task` related endpoints, covering:
- [list tasks](https://documentation.onfido.com/#list-tasks)
- [find a task](https://documentation.onfido.com/#retrieve-task)
- [complete a task](https://documentation.onfido.com/#complete-task)