### PR TITLE
Change the way npm token is provided to npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build and publish package
-        run: npm publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=\${NPM_AUTH_TOKEN}" > .npmrc
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/test/resources/workflow-runs-outputs.test.ts
+++ b/test/resources/workflow-runs-outputs.test.ts
@@ -115,7 +115,7 @@ describe("workflow runs outputs", () => {
         },
         country_residence: expect.stringMatching(/^[A-Z]{3}$/),
         dob: expect.stringMatching(/^[0-9-]+$/),
-        email: expect.stringMatching(/^[0-9A-Za-z@\.]+$/),
+        email: expect.stringMatching(/^[0-9A-Za-z_@\.]+$/),
         first_name: expect.stringMatching(/^[A-Za-z\s]+$/),
         last_name: expect.stringMatching(/^[A-Za-z\s]+$/),
         nationality: expect.stringMatching(/^[A-Z]{3}$/),


### PR DESCRIPTION
This change is to avoid error below at npm package creation:
```sh
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in to github:onfido/onfido-node
npm ERR! need auth You need to authorize this machine using `npm adduser`
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2024-05-06T13_46_38_2[49](https://github.com/onfido/onfido-node/actions/runs/8970161333/job/24633144169#step:5:50)Z-debug-0.log
Error: Process completed with exit code 1.
```

Solution seems to be adding token to .npm file (on top of [setting](https://github.com/npm/cli/issues/6184) registry-url, already there):
- https://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules

Includes a fix to [flaky test](https://github.com/onfido/onfido-node/actions/runs/8970536800/job/24634288517?pr=118) reported below:
```
        "dob": StringMatching /^[0-9-]+$/,
    -   "email": StringMatching /^[0-9A-Za-z@\.]+$/,
    +   "email": "Mitchell_Steuber21@gmail.com",
        "first_name": StringMatching /^[A-Za-z\s]+$/,
```