### PR TITLE
Additional fix to npm delivery

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,6 @@ jobs:
         run: npm ci
       - name: Build and publish package
         run: |
-          echo "//registry.npmjs.org/:_authToken=\${NPM_AUTH_TOKEN}" > .npmrc
           npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "typescript": "^4.0"
   },
   "publishConfig": {
-    "registry": "github:onfido/onfido-node"
+    "access": "public"
   }
 }

--- a/test/resources/workflow-runs-outputs.test.ts
+++ b/test/resources/workflow-runs-outputs.test.ts
@@ -116,8 +116,8 @@ describe("workflow runs outputs", () => {
         country_residence: expect.stringMatching(/^[A-Z]{3}$/),
         dob: expect.stringMatching(/^[0-9-]+$/),
         email: expect.stringMatching(/^[0-9A-Za-z_@\.]+$/),
-        first_name: expect.stringMatching(/^[A-Za-z\s]+$/),
-        last_name: expect.stringMatching(/^[A-Za-z\s]+$/),
+        first_name: expect.stringMatching(/^[A-Za-z\s-]+$/),
+        last_name: expect.stringMatching(/^[A-Za-z\s-]+$/),
         nationality: expect.stringMatching(/^[A-Z]{3}$/),
         phone_number: expect.stringMatching(/^\+[0-9]+$/),
         phone_number_consent_granted: expect.anything()


### PR DESCRIPTION
It ended up that change to delivery CI in https://github.com/onfido/onfido-node/pull/119 was wrong, as the problem was due to the auto-generated package.json pointing to github registry instead that npm one; change will be persisted in templates in https://github.com/onfido/onfido-openapi-spec/pull/71.

Took the opportunity for fixing another flaky test.