### PR TITLE
Refresh onfido-node after onfido-openapi-spec update (62dc554)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -30,6 +30,16 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node${{ matrix.node-version }}-
       - name: Install dependencies
         run: npm ci
       - name: Run linter over tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.0 4th June 2024
+
+- Refresh library up to commit: [62dc554](https://github.com/onfido/onfido-openapi-spec/commit/62dc5541a4a51e8de313fc99fb3dec496033a23e)
+
 ## v3.1.0 17th May 2024
 
 - Refresh library up to commit: [6dacb71](https://github.com/onfido/onfido-openapi-spec/commit/6dacb71ce66ee346fb729ff5bd43f5b9b98f62e0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Changelog
 
-## v4.0.0 4th June 2024
+## v4.0.0 10th June 2024
 
 - Refresh library up to commit: [62dc554](https://github.com/onfido/onfido-openapi-spec/commit/62dc5541a4a51e8de313fc99fb3dec496033a23e)
 
-## v3.1.0 17th May 2024
-
-- Refresh library up to commit: [6dacb71](https://github.com/onfido/onfido-openapi-spec/commit/6dacb71ce66ee346fb729ff5bd43f5b9b98f62e0)
-
-## v3.0.0 6th May 2024
+## v3.0.0 6th May 2024 (pre-release)
 
 - Make library auto-generated and based on [Onfido OpenAPI spec](https://github.com/onfido/onfido-openapi-spec)
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Webhook events payload needs to be verified before it can be accessed. Library a
 ```js
 (async () => {
   try {
-    const verifier = new WebhookEventVerifier("_ABC123abc...3ABC123_");
+    const token = process.env.ONFIDO_WEBHOOK_SECRET_TOKEN;
+    const verifier = new WebhookEventVerifier(token);
     const signature = "a0...760e";
 
     const event = verifier.readPayload(`{"payload":{"r...3"}}`, signature);

--- a/api.ts
+++ b/api.ts
@@ -5622,19 +5622,6 @@ export interface FacialSimilarityVideoReport {
 /**
  * 
  * @export
- * @interface IDPhotosList
- */
-export interface IDPhotosList {
-    /**
-     * 
-     * @type {Array<IdPhoto>}
-     * @memberof IDPhotosList
-     */
-    'id_photos': Array<IdPhoto>;
-}
-/**
- * 
- * @export
  * @interface IdNumber
  */
 export interface IdNumber {
@@ -5770,6 +5757,19 @@ export interface IdPhotoResponse {
      * @memberof IdPhotoResponse
      */
     'file_size'?: number;
+}
+/**
+ * 
+ * @export
+ * @interface IdPhotosList
+ */
+export interface IdPhotosList {
+    /**
+     * 
+     * @type {Array<IdPhoto>}
+     * @memberof IdPhotosList
+     */
+    'id_photos': Array<IdPhoto>;
 }
 /**
  * 
@@ -7708,25 +7708,6 @@ export interface TimelineFileReference {
      * Link to access the Timefile File that will be created.
      * @type {string}
      * @memberof TimelineFileReference
-     */
-    'href': string;
-}
-/**
- * 
- * @export
- * @interface TimelineFileReference1
- */
-export interface TimelineFileReference1 {
-    /**
-     * The unique identifier for the Timefile File that will be created.
-     * @type {string}
-     * @memberof TimelineFileReference1
-     */
-    'workflow_timeline_file_id': string;
-    /**
-     * Link to access the Timefile File that will be created.
-     * @type {string}
-     * @memberof TimelineFileReference1
      */
     'href': string;
 }
@@ -12848,7 +12829,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async findTimelineFile(workflowRunId: string, timelineFileId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Error>> {
+        async findTimelineFile(workflowRunId: string, timelineFileId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.findTimelineFile(workflowRunId, timelineFileId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.findTimelineFile']?.[localVarOperationServerIndex]?.url;
@@ -12967,7 +12948,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listIdPhotos(applicantId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<IDPhotosList>> {
+        async listIdPhotos(applicantId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<IdPhotosList>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.listIdPhotos(applicantId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.listIdPhotos']?.[localVarOperationServerIndex]?.url;
@@ -13616,7 +13597,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findTimelineFile(workflowRunId: string, timelineFileId: string, options?: any): AxiosPromise<Error> {
+        findTimelineFile(workflowRunId: string, timelineFileId: string, options?: any): AxiosPromise<File> {
             return localVarFp.findTimelineFile(workflowRunId, timelineFileId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13708,7 +13689,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listIdPhotos(applicantId: string, options?: any): AxiosPromise<IDPhotosList> {
+        listIdPhotos(applicantId: string, options?: any): AxiosPromise<IdPhotosList> {
             return localVarFp.listIdPhotos(applicantId, options).then((request) => request(axios, basePath));
         },
         /**

--- a/configuration.ts
+++ b/configuration.ts
@@ -101,7 +101,7 @@ export class Configuration {
         this.baseOptions = {...{ timeout: 30_000 },
                             ...param.baseOptions,
                             ...{ headers: {...param.baseOptions?.headers,
-                                           ...{'User-Agent': 'onfido-node/3.1.0'}}}};
+                                           ...{'User-Agent': 'onfido-node/4.0.0'}}}};
         this.formDataCtor = param.formDataCtor || require('form-data');         // Injiect form data constructor (if needed)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onfido/api",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onfido/api",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.1"
@@ -1509,9 +1509,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001621",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
-      "integrity": "sha512-+NLXZiviFFKX0fk8Piwv3PfLPGtRqJeq2TiNoUff/qB5KJgwecJTvCXDpmlyP/eCI/GUEmp/h/y5j0yckiiZrA==",
+      "version": "1.0.30001627",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001627.tgz",
+      "integrity": "sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==",
       "dev": true,
       "funding": [
         {
@@ -1769,9 +1769,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1892,9 +1892,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.782",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.782.tgz",
-      "integrity": "sha512-JUfU61e8tr+i5Y1FKXcKs+Xe+rJ+CEqm4cgv1kMihPE2EvYHmYyVr3Im/+1+Z5B29Be2EEGCZCwAc6Tazdl1Yg==",
+      "version": "1.4.789",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.789.tgz",
+      "integrity": "sha512-0VbyiaXoT++Fi2vHGo2ThOeS6X3vgRCWrjPeO2FeIAWL6ItiSJ9BqlH8LfCXe3X1IdcG+S0iLoNaxQWhfZoGzQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2379,6 +2379,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -4421,6 +4422,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/api",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Node.js library for the Onfido API",
   "author": "OpenAPI-Generator Contributors",
   "repository": {


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@62dc5541a4a51e8de313fc99fb3dec496033a23e (included)

Additional changes:
  - [Enable caching on Maven local repository and update CHANGELOG](https://github.com/onfido/onfido-node/pull/124/commits/6802936780304f82e2bec7027389803f10ee9e9d)