### PR TITLE
Refresh onfido-node after onfido-openapi-spec update (e92d340)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "38a8740",
-    "long_sha": "38a87401552386cb0b17aae28385c5e2f4af7bfc",
+    "short_sha": "e92d340",
+    "long_sha": "e92d340b84690cce6851fa4a32530ac29911d75a",
     "version": ""
   },
   "release": "v4.0.0"

--- a/api.tsE
+++ b/api.tsE
@@ -12316,7 +12316,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Upload a document
          * @param {string} type The type of document
          * @param {string} applicantId The ID of the applicant whose document is being uploaded.
-         * @param {FileTransfer} file The file to be uploaded.
+         * @param {File} file The file to be uploaded.
          * @param {UploadDocumentFileTypeEnum} [fileType] The file type of the uploaded file
          * @param {UploadDocumentSideEnum} [side] The side of the document, if applicable. The possible values are front and back
          * @param {CountryCodes} [issuingCountry] The issuing country of the document, a 3-letter ISO code.
@@ -12325,7 +12325,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadDocument: async (type: string, applicantId: string, file: FileTransfer, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadDocument: async (type: string, applicantId: string, file: File, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'type' is not null or undefined
             assertParamExists('uploadDocument', 'type', type)
             // verify required parameter 'applicantId' is not null or undefined
@@ -12398,11 +12398,11 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * You can upload ID photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. 
          * @summary Upload ID photo
          * @param {string} [applicantId] The ID of the applicant whose ID photo is being uploaded.
-         * @param {FileTransfer} [file] The file to be uploaded.
+         * @param {File} [file] The file to be uploaded.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadIdPhoto: async (applicantId?: string, file?: FileTransfer, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadIdPhoto: async (applicantId?: string, file?: File, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/id_photos`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -12445,12 +12445,12 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * You can upload live photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. Live photos are validated at the point of upload to check that they contain exactly one face. This validation can be disabled by setting the advanced_validation argument to false. 
          * @summary Upload live photo
          * @param {string} [applicantId] The ID of the applicant whose live photo is being uploaded.
-         * @param {FileTransfer} [file] The file to be uploaded.
+         * @param {File} [file] The file to be uploaded.
          * @param {boolean} [advancedValidation] Validates that the live photo contains exactly one face.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadLivePhoto: async (applicantId?: string, file?: FileTransfer, advancedValidation?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadLivePhoto: async (applicantId?: string, file?: File, advancedValidation?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/live_photos`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -12655,7 +12655,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadCheck(checkId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadCheck(checkId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadCheck(checkId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadCheck']?.[localVarOperationServerIndex]?.url;
@@ -12668,7 +12668,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadDocument(documentId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadDocument(documentId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadDocument(documentId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadDocument']?.[localVarOperationServerIndex]?.url;
@@ -12681,7 +12681,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadDocumentVideo(documentId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadDocumentVideo(documentId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadDocumentVideo(documentId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadDocumentVideo']?.[localVarOperationServerIndex]?.url;
@@ -12694,7 +12694,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadIdPhoto(idPhotoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadIdPhoto(idPhotoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadIdPhoto(idPhotoId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadIdPhoto']?.[localVarOperationServerIndex]?.url;
@@ -12707,7 +12707,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadLivePhoto(livePhotoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadLivePhoto(livePhotoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadLivePhoto(livePhotoId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadLivePhoto']?.[localVarOperationServerIndex]?.url;
@@ -12720,7 +12720,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadLiveVideo(liveVideoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadLiveVideo(liveVideoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadLiveVideo(liveVideoId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadLiveVideo']?.[localVarOperationServerIndex]?.url;
@@ -12733,7 +12733,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadLiveVideoFrame(liveVideoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadLiveVideoFrame(liveVideoId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadLiveVideoFrame(liveVideoId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadLiveVideoFrame']?.[localVarOperationServerIndex]?.url;
@@ -12746,7 +12746,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadMotionCapture(motionCaptureId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadMotionCapture(motionCaptureId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadMotionCapture(motionCaptureId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadMotionCapture']?.[localVarOperationServerIndex]?.url;
@@ -12759,7 +12759,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadMotionCaptureFrame(motionCaptureId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadMotionCaptureFrame(motionCaptureId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadMotionCaptureFrame(motionCaptureId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadMotionCaptureFrame']?.[localVarOperationServerIndex]?.url;
@@ -12772,7 +12772,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadSignedEvidenceFile(workflowRunId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async downloadSignedEvidenceFile(workflowRunId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.downloadSignedEvidenceFile(workflowRunId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadSignedEvidenceFile']?.[localVarOperationServerIndex]?.url;
@@ -12930,7 +12930,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async findTimelineFile(workflowRunId: string, timelineFileId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+        async findTimelineFile(workflowRunId: string, timelineFileId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.findTimelineFile(workflowRunId, timelineFileId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.findTimelineFile']?.[localVarOperationServerIndex]?.url;
@@ -13313,7 +13313,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Upload a document
          * @param {string} type The type of document
          * @param {string} applicantId The ID of the applicant whose document is being uploaded.
-         * @param {FileTransfer} file The file to be uploaded.
+         * @param {File} file The file to be uploaded.
          * @param {UploadDocumentFileTypeEnum} [fileType] The file type of the uploaded file
          * @param {UploadDocumentSideEnum} [side] The side of the document, if applicable. The possible values are front and back
          * @param {CountryCodes} [issuingCountry] The issuing country of the document, a 3-letter ISO code.
@@ -13322,7 +13322,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadDocument(type: string, applicantId: string, file: FileTransfer, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Document>> {
+        async uploadDocument(type: string, applicantId: string, file: File, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Document>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.uploadDocument(type, applicantId, file, fileType, side, issuingCountry, validateImageQuality, location, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.uploadDocument']?.[localVarOperationServerIndex]?.url;
@@ -13332,11 +13332,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * You can upload ID photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. 
          * @summary Upload ID photo
          * @param {string} [applicantId] The ID of the applicant whose ID photo is being uploaded.
-         * @param {FileTransfer} [file] The file to be uploaded.
+         * @param {File} [file] The file to be uploaded.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadIdPhoto(applicantId?: string, file?: FileTransfer, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<IdPhoto>> {
+        async uploadIdPhoto(applicantId?: string, file?: File, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<IdPhoto>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.uploadIdPhoto(applicantId, file, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.uploadIdPhoto']?.[localVarOperationServerIndex]?.url;
@@ -13346,12 +13346,12 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * You can upload live photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. Live photos are validated at the point of upload to check that they contain exactly one face. This validation can be disabled by setting the advanced_validation argument to false. 
          * @summary Upload live photo
          * @param {string} [applicantId] The ID of the applicant whose live photo is being uploaded.
-         * @param {FileTransfer} [file] The file to be uploaded.
+         * @param {File} [file] The file to be uploaded.
          * @param {boolean} [advancedValidation] Validates that the live photo contains exactly one face.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadLivePhoto(applicantId?: string, file?: FileTransfer, advancedValidation?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<LivePhoto>> {
+        async uploadLivePhoto(applicantId?: string, file?: File, advancedValidation?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<LivePhoto>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.uploadLivePhoto(applicantId, file, advancedValidation, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.uploadLivePhoto']?.[localVarOperationServerIndex]?.url;
@@ -13486,7 +13486,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadCheck(checkId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadCheck(checkId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadCheck(checkId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13496,7 +13496,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadDocument(documentId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadDocument(documentId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadDocument(documentId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13506,7 +13506,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadDocumentVideo(documentId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadDocumentVideo(documentId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadDocumentVideo(documentId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13516,7 +13516,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadIdPhoto(idPhotoId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadIdPhoto(idPhotoId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadIdPhoto(idPhotoId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13526,7 +13526,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadLivePhoto(livePhotoId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadLivePhoto(livePhotoId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadLivePhoto(livePhotoId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13536,7 +13536,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadLiveVideo(liveVideoId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadLiveVideo(liveVideoId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadLiveVideo(liveVideoId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13546,7 +13546,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadLiveVideoFrame(liveVideoId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadLiveVideoFrame(liveVideoId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadLiveVideoFrame(liveVideoId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13556,7 +13556,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadMotionCapture(motionCaptureId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadMotionCapture(motionCaptureId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadMotionCapture(motionCaptureId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13566,7 +13566,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadMotionCaptureFrame(motionCaptureId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadMotionCaptureFrame(motionCaptureId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadMotionCaptureFrame(motionCaptureId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13576,7 +13576,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadSignedEvidenceFile(workflowRunId: string, options?: any): AxiosPromise<FileTransfer> {
+        downloadSignedEvidenceFile(workflowRunId: string, options?: any): AxiosPromise<File> {
             return localVarFp.downloadSignedEvidenceFile(workflowRunId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13698,7 +13698,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findTimelineFile(workflowRunId: string, timelineFileId: string, options?: any): AxiosPromise<FileTransfer> {
+        findTimelineFile(workflowRunId: string, timelineFileId: string, options?: any): AxiosPromise<File> {
             return localVarFp.findTimelineFile(workflowRunId, timelineFileId, options).then((request) => request(axios, basePath));
         },
         /**
@@ -13994,7 +13994,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @summary Upload a document
          * @param {string} type The type of document
          * @param {string} applicantId The ID of the applicant whose document is being uploaded.
-         * @param {FileTransfer} file The file to be uploaded.
+         * @param {File} file The file to be uploaded.
          * @param {UploadDocumentFileTypeEnum} [fileType] The file type of the uploaded file
          * @param {UploadDocumentSideEnum} [side] The side of the document, if applicable. The possible values are front and back
          * @param {CountryCodes} [issuingCountry] The issuing country of the document, a 3-letter ISO code.
@@ -14003,30 +14003,30 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadDocument(type: string, applicantId: string, file: FileTransfer, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options?: any): AxiosPromise<Document> {
+        uploadDocument(type: string, applicantId: string, file: File, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options?: any): AxiosPromise<Document> {
             return localVarFp.uploadDocument(type, applicantId, file, fileType, side, issuingCountry, validateImageQuality, location, options).then((request) => request(axios, basePath));
         },
         /**
          * You can upload ID photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. 
          * @summary Upload ID photo
          * @param {string} [applicantId] The ID of the applicant whose ID photo is being uploaded.
-         * @param {FileTransfer} [file] The file to be uploaded.
+         * @param {File} [file] The file to be uploaded.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadIdPhoto(applicantId?: string, file?: FileTransfer, options?: any): AxiosPromise<IdPhoto> {
+        uploadIdPhoto(applicantId?: string, file?: File, options?: any): AxiosPromise<IdPhoto> {
             return localVarFp.uploadIdPhoto(applicantId, file, options).then((request) => request(axios, basePath));
         },
         /**
          * You can upload live photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. Live photos are validated at the point of upload to check that they contain exactly one face. This validation can be disabled by setting the advanced_validation argument to false. 
          * @summary Upload live photo
          * @param {string} [applicantId] The ID of the applicant whose live photo is being uploaded.
-         * @param {FileTransfer} [file] The file to be uploaded.
+         * @param {File} [file] The file to be uploaded.
          * @param {boolean} [advancedValidation] Validates that the live photo contains exactly one face.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadLivePhoto(applicantId?: string, file?: FileTransfer, advancedValidation?: boolean, options?: any): AxiosPromise<LivePhoto> {
+        uploadLivePhoto(applicantId?: string, file?: File, advancedValidation?: boolean, options?: any): AxiosPromise<LivePhoto> {
             return localVarFp.uploadLivePhoto(applicantId, file, advancedValidation, options).then((request) => request(axios, basePath));
         },
     };
@@ -14788,7 +14788,7 @@ export class DefaultApi extends BaseAPI {
      * @summary Upload a document
      * @param {string} type The type of document
      * @param {string} applicantId The ID of the applicant whose document is being uploaded.
-     * @param {FileTransfer} file The file to be uploaded.
+     * @param {File} file The file to be uploaded.
      * @param {UploadDocumentFileTypeEnum} [fileType] The file type of the uploaded file
      * @param {UploadDocumentSideEnum} [side] The side of the document, if applicable. The possible values are front and back
      * @param {CountryCodes} [issuingCountry] The issuing country of the document, a 3-letter ISO code.
@@ -14798,7 +14798,7 @@ export class DefaultApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public uploadDocument(type: string, applicantId: string, file: FileTransfer, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options?: RawAxiosRequestConfig) {
+    public uploadDocument(type: string, applicantId: string, file: File, fileType?: UploadDocumentFileTypeEnum, side?: UploadDocumentSideEnum, issuingCountry?: CountryCodes, validateImageQuality?: boolean, location?: LocationBuilder, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).uploadDocument(type, applicantId, file, fileType, side, issuingCountry, validateImageQuality, location, options).then((request) => request(this.axios, this.basePath));
     }
 
@@ -14806,12 +14806,12 @@ export class DefaultApi extends BaseAPI {
      * You can upload ID photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. 
      * @summary Upload ID photo
      * @param {string} [applicantId] The ID of the applicant whose ID photo is being uploaded.
-     * @param {FileTransfer} [file] The file to be uploaded.
+     * @param {File} [file] The file to be uploaded.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public uploadIdPhoto(applicantId?: string, file?: FileTransfer, options?: RawAxiosRequestConfig) {
+    public uploadIdPhoto(applicantId?: string, file?: File, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).uploadIdPhoto(applicantId, file, options).then((request) => request(this.axios, this.basePath));
     }
 
@@ -14819,13 +14819,13 @@ export class DefaultApi extends BaseAPI {
      * You can upload live photos to this endpoint. Like document upload, files must be uploaded as a multipart form. Valid file types are jpg, png and pdf. The file size must be between 32KB and 10MB. Live photos are validated at the point of upload to check that they contain exactly one face. This validation can be disabled by setting the advanced_validation argument to false. 
      * @summary Upload live photo
      * @param {string} [applicantId] The ID of the applicant whose live photo is being uploaded.
-     * @param {FileTransfer} [file] The file to be uploaded.
+     * @param {File} [file] The file to be uploaded.
      * @param {boolean} [advancedValidation] Validates that the live photo contains exactly one face.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public uploadLivePhoto(applicantId?: string, file?: FileTransfer, advancedValidation?: boolean, options?: RawAxiosRequestConfig) {
+    public uploadLivePhoto(applicantId?: string, file?: File, advancedValidation?: boolean, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).uploadLivePhoto(applicantId, file, advancedValidation, options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/file-transfer.ts
+++ b/file-transfer.ts
@@ -1,0 +1,20 @@
+import { readFileSync, PathLike } from "fs";
+
+export class FileTransfer {
+  public readonly buffer: Buffer;
+  public readonly filename: String;
+
+  constructor(buffer: String, filename: String);
+  constructor(buffer: Buffer, filename: String);
+  constructor(inputFile: PathLike);
+
+  constructor(data?: String | Buffer | PathLike, filename?: String) {
+    if (filename == null) {
+      this.buffer = readFileSync(data as PathLike);
+      this.filename = (data as PathLike).toString();
+    } else {
+      this.buffer = data as Buffer;
+      this.filename = filename;
+    }
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -17,3 +17,4 @@ export * from "./api";
 export * from "./configuration";
 
 export * from "./webhook-event-verifier";
+export * from "./file-transfer";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,9 +1057,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001633",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001633.tgz",
-      "integrity": "sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg==",
+      "version": "1.0.30001636",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+      "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
       "dev": true,
       "funding": [
         {
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.802",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.802.tgz",
-      "integrity": "sha512-TnTMUATbgNdPXVSHsxvNVSG0uEd6cSZsANjm8c9HbvflZVVn1yTRcmVXYT1Ma95/ssB/Dcd30AHweH2TE+dNpA==",
+      "version": "1.4.807",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.807.tgz",
+      "integrity": "sha512-kSmJl2ZwhNf/bcIuCH/imtNOKlpkLDn2jqT5FJ+/0CXjhnFaOa9cOe9gHKKy71eM49izwuQjZhKk+lWQ1JxB7A==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5772,9 +5772,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"

--- a/test/file-transfer.test.ts
+++ b/test/file-transfer.test.ts
@@ -1,0 +1,25 @@
+import { FileTransfer } from "onfido-node";
+import { createReadStream, readFileSync } from "fs";
+
+
+it("create a file transfer from a string and filename", () => {
+  const fileTransfer = new FileTransfer("PAYLOAD", "test-file.jpg")
+
+  expect(fileTransfer.filename).toEqual("test-file.jpg");
+  expect(fileTransfer.buffer.toString()).toEqual("PAYLOAD");
+});
+
+it("create a file transfer from a buffer and filename", () => {
+  let buffer = readFileSync("test/media/sample_photo.png");
+  const fileTransfer = new FileTransfer(buffer, "filename.png")
+
+  expect(fileTransfer.filename).toEqual("filename.png");
+  expect(fileTransfer.buffer.slice(1, 4).toString()).toEqual("PNG");
+});
+
+it("create a file transfer from a file path", () => {
+  const fileTransfer = new FileTransfer("test/media/sample_photo.png")
+
+  expect(fileTransfer.filename).toEqual("test/media/sample_photo.png");
+  expect(fileTransfer.buffer.slice(1, 4).toString()).toEqual("PNG");
+});

--- a/test/resources/checks.test.ts
+++ b/test/resources/checks.test.ts
@@ -153,5 +153,6 @@ it("downloads a check", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("application/pdf");
-  expect(file.data.slice(0, 5)).toEqual("%PDF-");
+  expect(file.data.buffer.slice(0, 5)).toEqual("%PDF-");
+  expect(file.data.filename).toBeTruthy();
 });

--- a/test/resources/documents.test.ts
+++ b/test/resources/documents.test.ts
@@ -42,7 +42,8 @@ it("downloads a document", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("image/png");
-  expect(file.data.slice(1, 4)).toEqual("PNG");
+  expect(file.data.buffer.slice(1, 4)).toEqual("PNG");
+  expect(file.data.filename).toBeTruthy();
 });
 
 it("finds a document", async () => {

--- a/test/resources/id-photos.test.ts
+++ b/test/resources/id-photos.test.ts
@@ -49,7 +49,8 @@ it("downloads a id photo", async () => {
   const file = await onfido.downloadIdPhoto(photo.data.id);
 
   expect(file.status).toEqual(200);
-  expect(file.data.slice(1, 4)).toEqual("PNG");
+  expect(file.data.buffer.slice(1, 4)).toEqual("PNG");
+  expect(file.data.filename).toBeTruthy();
 });
 
 it("finds a id photo", async () => {

--- a/test/resources/live-photos.test.ts
+++ b/test/resources/live-photos.test.ts
@@ -54,7 +54,8 @@ it("downloads a live photo", async () => {
   const file = await onfido.downloadLivePhoto(photo.data.id);
 
   expect(file.status).toEqual(200);
-  expect(file.data.slice(1, 4)).toEqual("PNG");
+  expect(file.data.buffer.slice(1, 4)).toEqual("PNG");
+  expect(file.data.filename).toEqual("sample_photo.png");
 });
 
 it("finds a live photo", async () => {

--- a/test/resources/live-videos.test.ts
+++ b/test/resources/live-videos.test.ts
@@ -41,6 +41,7 @@ it("downloads a live video", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("video/quicktime");
+  expect(file.data.filename).toEqual("video.mov");
 });
 
 it("downloads a live video frame", async () => {
@@ -48,7 +49,8 @@ it("downloads a live video frame", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("image/jpeg");
-  expect(file.data.slice(0, 10)).toContain("JFIF");
+  expect(file.data.buffer.slice(0, 10)).toContain("JFIF");
+  expect(file.data.filename).toBeTruthy();
 });
 
 it("finds a live video", async () => {

--- a/test/resources/motion-captures.test.ts
+++ b/test/resources/motion-captures.test.ts
@@ -38,6 +38,7 @@ it("downloads a motion capture", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toContain("video/mp4");
+  expect(file.data.filename).toBeTruthy();
 });
 
 it("downloads a motion capture frame", async () => {
@@ -45,7 +46,8 @@ it("downloads a motion capture frame", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toContain("image/jpeg");
-  expect(file.data.slice(0, 10)).toContain("JFIF");
+  expect(file.data.buffer.slice(0, 10)).toContain("JFIF");
+  expect(file.data.filename).toBeTruthy();
 });
 
 it("finds a motion capture", async () => {

--- a/test/resources/workflow-runs.test.ts
+++ b/test/resources/workflow-runs.test.ts
@@ -107,7 +107,7 @@ it("downloads a signed evidence file", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("application/pdf");
-  expect(file.data.slice(0, 5)).toEqual("%PDF-");
+  expect(file.data.buffer.slice(0, 5)).toEqual("%PDF-");
 });
 
 it("generates a timeline file", async () => {
@@ -147,5 +147,5 @@ it("downloads a timeline file", async () => {
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("binary/octet-stream");
-  expect(file.data.slice(0, 5)).toEqual("%PDF-");
+  expect(file.data.buffer.slice(0, 5)).toEqual("%PDF-");
 }, 30000);

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,5 +1,5 @@
 import { isAxiosError } from "axios";
-import { createReadStream } from "fs";
+import { createReadStream, readFileSync } from "fs";
 import "dotenv/config";
 
 import {
@@ -10,6 +10,7 @@ import {
   Document,
   DocumentReport,
   FacialSimilarityPhotoReport,
+  FileTransfer,
   LiveVideo,
   MotionCapture,
   Report,
@@ -23,6 +24,8 @@ export const onfido = new DefaultApi(
     baseOptions: { timeout: 60_000 }
   })
 );
+
+jest.setTimeout(60_000);
 
 export const sampleapplicant_id =
   process.env.ONFIDO_SAMPLE_APPLICANT_ID || "sample_applicant_id";
@@ -83,37 +86,28 @@ export async function cleanUpApplicants() {
   });
 }
 
-export async function uploadDocumentFromStream(
-  applicant: Applicant,
-  readStream: File,
-  documentType = "driving_licence"
-) {
-  return onfido.uploadDocument(documentType, applicant.id, readStream);
-}
-
 export async function uploadDocument(
   applicant: Applicant,
   documentType = "driving_licence"
 ) {
-  let readStream: any = createReadStream(
-    "test/media/sample_driving_licence.png"
-  );
-  return uploadDocumentFromStream(applicant, readStream, documentType);
+  let fileTransfer = new FileTransfer("test/media/sample_driving_licence.png");
+
+  return onfido.uploadDocument(documentType, applicant.id, fileTransfer);
 }
 
 export async function uploadLivePhoto(
   applicant: Applicant,
   advancedValidation?: boolean
 ) {
-  let readStream: any = createReadStream("test/media/sample_photo.png");
+  let buffer = readFileSync("test/media/sample_photo.png");
 
-  return onfido.uploadLivePhoto(applicant.id, readStream, advancedValidation);
+  return onfido.uploadLivePhoto(applicant.id, new FileTransfer(buffer, "sample_photo.png"), advancedValidation);
 }
 
 export async function uploadIdPhoto(applicant: Applicant) {
-  let readStream: any = createReadStream("test/media/sample_photo.png");
+  let fileTransfer = new FileTransfer("test/media/sample_photo.png");
 
-  return onfido.uploadIdPhoto(applicant.id, readStream);
+  return onfido.uploadIdPhoto(applicant.id, fileTransfer);
 }
 
 export async function createWebhook() {


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@e92d340b84690cce6851fa4a32530ac29911d75a (included)

Additional changes:
  - [Use FileTransfer object in tests](https://github.com/onfido/onfido-node/pull/130/commits/a0918fb07418503f3f7233331b70f54511ccd6a1)