### PR TITLE
Refresh onfido-node after onfido-openapi-spec update (40b86a1)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "01ed1b5",
-    "long_sha": "01ed1b5fe0f7490bfce54816504a9fec13b33862",
-    "version": "v3.1.0"
+    "short_sha": "40b86a1",
+    "long_sha": "40b86a1c8ec8687c15514470f60428b3e7633968",
+    "version": "v3.2.0"
   },
-  "release": "v3.2.0"
+  "release": "v3.3.0"
 }

--- a/api.ts
+++ b/api.ts
@@ -1837,6 +1837,7 @@ export interface Document {
 
 export const DocumentFileTypeEnum = {
     Jpg: 'jpg',
+    Jpeg: 'jpeg',
     Png: 'png',
     Pdf: 'pdf',
     UnknownDefaultOpenApi: '11184809'
@@ -2908,6 +2909,18 @@ export interface DocumentProperties {
      * @type {string}
      * @memberof DocumentProperties
      */
+    'middle_name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentProperties
+     */
+    'last_name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentProperties
+     */
     'gender'?: string;
     /**
      * 
@@ -2915,12 +2928,6 @@ export interface DocumentProperties {
      * @memberof DocumentProperties
      */
     'issuing_country'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof DocumentProperties
-     */
-    'last_name'?: string;
     /**
      * 
      * @type {string}
@@ -3773,6 +3780,7 @@ export interface DocumentShared {
 
 export const DocumentSharedFileTypeEnum = {
     Jpg: 'jpg',
+    Jpeg: 'jpeg',
     Png: 'png',
     Pdf: 'pdf',
     UnknownDefaultOpenApi: '11184809'
@@ -4172,6 +4180,18 @@ export interface DocumentWithDriverVerificationReportAllOfProperties {
      * @type {string}
      * @memberof DocumentWithDriverVerificationReportAllOfProperties
      */
+    'middle_name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentWithDriverVerificationReportAllOfProperties
+     */
+    'last_name'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentWithDriverVerificationReportAllOfProperties
+     */
     'gender'?: string;
     /**
      * 
@@ -4179,12 +4199,6 @@ export interface DocumentWithDriverVerificationReportAllOfProperties {
      * @memberof DocumentWithDriverVerificationReportAllOfProperties
      */
     'issuing_country'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof DocumentWithDriverVerificationReportAllOfProperties
-     */
-    'last_name'?: string;
     /**
      * 
      * @type {string}
@@ -9651,6 +9665,12 @@ export interface WebhookEventPayloadObject {
      */
     'status'?: string;
     /**
+     * The date and time when the operation was started, if available.
+     * @type {string}
+     * @memberof WebhookEventPayloadObject
+     */
+    'started_at_iso8601'?: string;
+    /**
      * The date and time when the operation was completed, if available.
      * @type {string}
      * @memberof WebhookEventPayloadObject
@@ -10944,6 +10964,53 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
 
             // authentication Token required
             await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Retrieves the signed document or application form depending on the file_id provided. 
+         * @summary Retrieves the signed document or application form
+         * @param {string} workflowRunId The unique identifier of the Workflow Run for which you want to retrieve the signed document.
+         * @param {string} fileId The unique identifier of the file which you want to retrieve.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        downloadQesDocument: async (workflowRunId: string, fileId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'workflowRunId' is not null or undefined
+            assertParamExists('downloadQesDocument', 'workflowRunId', workflowRunId)
+            // verify required parameter 'fileId' is not null or undefined
+            assertParamExists('downloadQesDocument', 'fileId', fileId)
+            const localVarPath = `/qualified_electronic_signature/documents`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Token required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            if (workflowRunId !== undefined) {
+                localVarQueryParameter['workflow_run_id'] = workflowRunId;
+            }
+
+            if (fileId !== undefined) {
+                localVarQueryParameter['file_id'] = fileId;
+            }
 
 
     
@@ -13022,6 +13089,20 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Retrieves the signed document or application form depending on the file_id provided. 
+         * @summary Retrieves the signed document or application form
+         * @param {string} workflowRunId The unique identifier of the Workflow Run for which you want to retrieve the signed document.
+         * @param {string} fileId The unique identifier of the file which you want to retrieve.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async downloadQesDocument(workflowRunId: string, fileId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadQesDocument(workflowRunId, fileId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadQesDocument']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Retrieves the signed evidence file for the designated Workflow Run 
          * @summary Retrieve Workflow Run Evidence Summary File
          * @param {string} workflowRunId Workflow Run ID
@@ -13826,6 +13907,17 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.downloadMotionCaptureFrame(motionCaptureId, options).then((request) => request(axios, basePath));
         },
         /**
+         * Retrieves the signed document or application form depending on the file_id provided. 
+         * @summary Retrieves the signed document or application form
+         * @param {string} workflowRunId The unique identifier of the Workflow Run for which you want to retrieve the signed document.
+         * @param {string} fileId The unique identifier of the file which you want to retrieve.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        downloadQesDocument(workflowRunId: string, fileId: string, options?: any): AxiosPromise<FileTransfer> {
+            return localVarFp.downloadQesDocument(workflowRunId, fileId, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Retrieves the signed evidence file for the designated Workflow Run 
          * @summary Retrieve Workflow Run Evidence Summary File
          * @param {string} workflowRunId Workflow Run ID
@@ -14538,6 +14630,19 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
+     * Retrieves the signed document or application form depending on the file_id provided. 
+     * @summary Retrieves the signed document or application form
+     * @param {string} workflowRunId The unique identifier of the Workflow Run for which you want to retrieve the signed document.
+     * @param {string} fileId The unique identifier of the file which you want to retrieve.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public downloadQesDocument(workflowRunId: string, fileId: string, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).downloadQesDocument(workflowRunId, fileId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * Retrieves the signed evidence file for the designated Workflow Run 
      * @summary Retrieve Workflow Run Evidence Summary File
      * @param {string} workflowRunId Workflow Run ID
@@ -15100,6 +15205,7 @@ export type ListWorkflowRunsSortEnum = typeof ListWorkflowRunsSortEnum[keyof typ
  */
 export const UploadDocumentFileTypeEnum = {
     Jpg: 'jpg',
+    Jpeg: 'jpeg',
     Png: 'png',
     Pdf: 'pdf',
     UnknownDefaultOpenApi: '11184809'

--- a/configuration.ts
+++ b/configuration.ts
@@ -101,7 +101,7 @@ export class Configuration {
         this.baseOptions = {...{ timeout: 30_000 },
                             ...param.baseOptions,
                             ...{ headers: {...param.baseOptions?.headers,
-                                           ...{'User-Agent': 'onfido-node/3.2.0'}}}};
+                                           ...{'User-Agent': 'onfido-node/3.3.0'}}}};
         this.formDataCtor = param.formDataCtor || require('form-data');         // Injiect form data constructor (if needed)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onfido/api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onfido/api",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.1"
@@ -49,30 +49,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.9.tgz",
+      "integrity": "sha512-e701mcfApCJqMMueQI0Fb68Amflj83+dvAvHawoBpAz+GDjCIyGHzNwnefjsWJ3xiYAqqiQFoWbspGYBdb2/ng==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.9.tgz",
+      "integrity": "sha512-5e3FI4Q3M3Pbr21+5xJwCv6ZT6KmGkI0vw3Tozy5ODAQFTIWe37iT8Cr7Ice2Ntb+M3iSKCEWMB1MBgKrW3whg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helpers": "^7.24.7",
-        "@babel/parser": "^7.24.7",
+        "@babel/generator": "^7.24.9",
+        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/helper-module-transforms": "^7.24.9",
+        "@babel/helpers": "^7.24.8",
+        "@babel/parser": "^7.24.8",
         "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -94,12 +94,12 @@
       "dev": true
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.9.tgz",
+      "integrity": "sha512-G8v3jRg+z8IwY1jHFxvCNhOPYPterE4XljNgdGTYfSTtzzwjIswIzIaSPSLs3R7yFuqnqNeay5rjICfqVr+/6A==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.24.7",
+        "@babel/types": "^7.24.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -109,14 +109,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.8.tgz",
+      "integrity": "sha512-oU+UoqCHdp+nWVDkpldqIQL/i/bvAv53tRqLG/s+cOXxe66zOYLU7ar/Xs3LdmBihrUMEUhwu6dMZwbNOYDwvw==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.24.8",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
+      "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.24.7",
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -246,22 +246,22 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.8.tgz",
+      "integrity": "sha512-gV2265Nkcz7weJJfvDoAEVzC1e2OTDpkGbEsebse8koXUJUXPsCMi7sRo/+SPMuMZ9MtUPnGwITTnQnU5YjyaQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -527,19 +527,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
+        "@babel/generator": "^7.24.8",
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-function-name": "^7.24.7",
         "@babel/helper-hoist-variables": "^7.24.7",
         "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/parser": "^7.24.8",
+        "@babel/types": "^7.24.8",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -548,12 +548,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.24.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.9.tgz",
+      "integrity": "sha512-xm8XrMKz0IlUdocVbYJe0Z9xEgidU7msskG8BbhnTPK/HZ2z/7FP7ykqPgrUH+C+r414mNfNWam1f2vqOjqjYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1057,9 +1057,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1417,9 +1417,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
       "dev": true,
       "funding": [
         {
@@ -1436,10 +1436,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
+        "caniuse-lite": "^1.0.30001640",
+        "electron-to-chromium": "^1.4.820",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001639",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
-      "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
+      "version": "1.0.30001642",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
+      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
       "dev": true,
       "funding": [
         {
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.816",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz",
-      "integrity": "sha512-EKH5X5oqC6hLmiS7/vYtZHZFTNdhsYG5NVPRN6Yn0kQHNBlT59+xSM8HBy66P5fxWpKgZbPqb+diC64ng295Jw==",
+      "version": "1.4.827",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
+      "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3907,9 +3907,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
       "dev": true
     },
     "node_modules/object-copy": {
@@ -5554,9 +5554,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Node.js library for the Onfido API",
   "author": "OpenAPI-Generator Contributors",
   "repository": {

--- a/test/file-transfer.test.ts
+++ b/test/file-transfer.test.ts
@@ -1,9 +1,8 @@
 import { FileTransfer } from "onfido-node";
 import { createReadStream, readFileSync } from "fs";
 
-
 it("create a file transfer from a string and filename", () => {
-  const fileTransfer = new FileTransfer("PAYLOAD", "test-file.jpg")
+  const fileTransfer = new FileTransfer("PAYLOAD", "test-file.jpg");
 
   expect(fileTransfer.filename).toEqual("test-file.jpg");
   expect(fileTransfer.buffer.toString()).toEqual("PAYLOAD");
@@ -11,14 +10,14 @@ it("create a file transfer from a string and filename", () => {
 
 it("create a file transfer from a buffer and filename", () => {
   let buffer = readFileSync("test/media/sample_photo.png");
-  const fileTransfer = new FileTransfer(buffer, "filename.png")
+  const fileTransfer = new FileTransfer(buffer, "filename.png");
 
   expect(fileTransfer.filename).toEqual("filename.png");
   expect(fileTransfer.buffer.slice(1, 4).toString()).toEqual("PNG");
 });
 
 it("create a file transfer from a file path", () => {
-  const fileTransfer = new FileTransfer("test/media/sample_photo.png")
+  const fileTransfer = new FileTransfer("test/media/sample_photo.png");
 
   expect(fileTransfer.filename).toEqual("test/media/sample_photo.png");
   expect(fileTransfer.buffer.slice(1, 4).toString()).toEqual("PNG");

--- a/test/resources/qualified-electronic-signature.test.ts
+++ b/test/resources/qualified-electronic-signature.test.ts
@@ -1,0 +1,63 @@
+import {
+  cleanUpApplicants,
+  cleanUpWebhooks,
+  createApplicant,
+  repeatRequestUntilTaskOutputChanges,
+  createWorkflowRunWithCustomInputs,
+  onfido,
+  sleep
+} from "../test-helpers";
+
+import { WorkflowRunBuilder } from "onfido-node";
+
+afterAll(() => {
+  return Promise.all([cleanUpApplicants(), cleanUpWebhooks()]);
+});
+
+it("downloads a signed document file", async () => {
+  function sleep(milliseconds) {
+    const date = Date.now();
+    let currentDate = null;
+    do {
+      currentDate = Date.now();
+    } while (currentDate - date < milliseconds);
+  }
+  const applicant = (await createApplicant()).data;
+
+  const workflowRunBuilder: WorkflowRunBuilder = {
+    applicant_id: applicant.id,
+    workflow_id: "8b74614f-9e7f-42fd-852a-5f2bcc852587",
+    custom_data: {
+      country_of_operation: "GBR",
+      document_date_of_expiry: "2022-01-01",
+      document_issuing_country: "FRA",
+      document_issuing_date: "2022-01-01",
+      document_number: "Example string",
+      document_to_sign_url:
+        "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+      document_type: "driving_licence"
+    }
+  };
+
+  const workflowRun = await createWorkflowRunWithCustomInputs(
+    workflowRunBuilder
+  );
+  const taskId = (await onfido.listTasks(workflowRun.data.id)).data[0].id;
+
+  const output = (
+    await repeatRequestUntilTaskOutputChanges(
+      "findTask",
+      [workflowRun.data.id, taskId],
+      10,
+      3000
+    )
+  )["output"];
+
+  const fileId = output["properties"]["signed_documents"][0]["id"];
+
+  const file = await onfido.downloadQesDocument(workflowRun.data.id, fileId);
+
+  expect(file.status).toEqual(200);
+  expect(file.headers["content-type"]).toEqual("application/pdf");
+  expect(file.data.buffer.slice(0, 5)).toEqual("%PDF-");
+});

--- a/test/resources/workflow-runs-outputs.test.ts
+++ b/test/resources/workflow-runs-outputs.test.ts
@@ -26,6 +26,7 @@ function getExpectedWorkflowRun(
   return getExpectedObject(exampleWorkflowRun, {
     applicant_id: expect.stringMatching(/^[0-9a-z-]+$/),
     id: expect.stringMatching(/^[0-9a-z-]+$/),
+    customer_user_id: expect.anything(),
     workflow_id: expect.stringMatching(/^[0-9a-z-]+$/),
     workflow_version_id: expect.anything(),
     dashboard_url: expect.anything(),

--- a/test/resources/workflow-runs.test.ts
+++ b/test/resources/workflow-runs.test.ts
@@ -25,6 +25,7 @@ function getExpectedWorkflowRun(
   return getExpectedObject(exampleWorkflowRun, {
     applicant_id: expect.stringMatching(/^[0-9a-z-]+$/),
     id: expect.stringMatching(/^[0-9a-z-]+$/),
+    customer_user_id: expect.anything(),
     workflow_id: expect.stringMatching(/^[0-9a-z-]+$/),
     workflow_version_id: expect.anything(),
     dashboard_url: expect.anything(),

--- a/test/test-examples.ts
+++ b/test/test-examples.ts
@@ -17,7 +17,7 @@ export const exampleApplicant: Applicant = {
   href: "/v3.6/applicants/123-abc",
   first_name: "Test",
   last_name: "Applicant",
-  email: null,
+  email: "first.last@gmail.com",
   dob: null,
   id_numbers: [],
   address: {
@@ -34,7 +34,7 @@ export const exampleApplicant: Applicant = {
     line2: null,
     line3: null
   },
-  phone_number: null,
+  phone_number: "351911111111",
   location: {
     ip_address: "127.0.0.1",
     country_of_residence: "GBR"

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -57,6 +57,8 @@ export async function createApplicant(overrideProperties = {}) {
       ip_address: "127.0.0.1",
       country_of_residence: "GBR"
     },
+    email: "first.last@gmail.com",
+    phone_number: "351911111111",
     ...overrideProperties
   });
 }
@@ -101,7 +103,11 @@ export async function uploadLivePhoto(
 ) {
   let buffer = readFileSync("test/media/sample_photo.png");
 
-  return onfido.uploadLivePhoto(applicant.id, new FileTransfer(buffer, "sample_photo.png"), advancedValidation);
+  return onfido.uploadLivePhoto(
+    applicant.id,
+    new FileTransfer(buffer, "sample_photo.png"),
+    advancedValidation
+  );
 }
 
 export async function uploadIdPhoto(applicant: Applicant) {
@@ -264,6 +270,27 @@ export async function repeatRequestUntilStatusChanges(
   while (instance.status != expectedStatus) {
     if (iteration >= maxRetries) {
       throw new Error("Status did not change in time");
+    }
+    iteration += 1;
+    await sleep(sleepTime);
+
+    instance = (await onfido[fn](...params)).data;
+  }
+  return instance;
+}
+
+export async function repeatRequestUntilTaskOutputChanges(
+  fn: string,
+  params: any[],
+  maxRetries = 10,
+  sleepTime = 1000
+): Promise<any> {
+  let instance = (await onfido[fn](...params)).data;
+  let iteration = 0;
+
+  while (instance["output"] === null) {
+    if (iteration >= maxRetries) {
+      throw new Error("Task output did not change in time");
     }
     iteration += 1;
     await sleep(sleepTime);


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@40b86a1c8ec8687c15514470f60428b3e7633968 (included)

Additional changes:
  - [Update tests after backward compatible change in API](https://github.com/onfido/onfido-node/pull/136/commits/5d6dbaa141fbae1451d3965d1415dd9a87ee6be1)
  - [test(qes): cover document download](https://github.com/onfido/onfido-node/pull/136/commits/a06d9371d35a009741c156dac25fef74e25219e2)