### PR TITLE
A few improvements to CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 21.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v4
@@ -35,17 +35,21 @@ jobs:
         shell: bash
         run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
       - uses: actions/cache@v4
+        id: cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node${{ matrix.node-version }}-
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Run linter over tests
-        run: npx prettier -c test/**/*.ts
+        run: |
+            npm install prettier
+            npx prettier -c test/**/*.ts
       - name: Run integration tests with NPM
-        if: ${{ matrix.node-version == '16.x' &&
+        if: ${{ matrix.node-version == '18.x' &&
           github.repository_owner == 'onfido' }}
         run: npm test -- -i
         env:
@@ -68,7 +72,7 @@ jobs:
           ref: master
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/
       - name: Validate release
         uses: onfido/onfido-actions/release-check@main


### PR DESCRIPTION
- Don't call npm ci if dependencies were cached
- Add version 22.x in CI, remove version 16
- Install prettier