### PR TITLE
Refresh onfido-node after onfido-openapi-spec update (54ce45f)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "964fb43",
-    "long_sha": "964fb43a1bf211197ef7a45c230771b8ba561b3c",
-    "version": "v4.4.0"
+    "short_sha": "54ce45f",
+    "long_sha": "54ce45f2138f044cc5cb40f6904dc7bc1a675be6",
+    "version": "v4.5.0"
   },
-  "release": "v4.4.0"
+  "release": "v4.5.0"
 }

--- a/api.ts
+++ b/api.ts
@@ -11399,6 +11399,43 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * Retrieves the evidence folder for the designated Workflow Run 
+         * @summary Retrieve Workflow Run Evidence Folder
+         * @param {string} workflowRunId Workflow Run ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        downloadEvidenceFolder: async (workflowRunId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'workflowRunId' is not null or undefined
+            assertParamExists('downloadEvidenceFolder', 'workflowRunId', workflowRunId)
+            const localVarPath = `/workflow_runs/{workflow_run_id}/evidence_folder`
+                .replace(`{${"workflow_run_id"}}`, encodeURIComponent(String(workflowRunId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Token required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * ID photos are downloaded using this endpoint.
          * @summary Download ID photo
          * @param {string} idPhotoId The ID photo\&#39;s unique identifier.
@@ -13655,6 +13692,19 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Retrieves the evidence folder for the designated Workflow Run 
+         * @summary Retrieve Workflow Run Evidence Folder
+         * @param {string} workflowRunId Workflow Run ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async downloadEvidenceFolder(workflowRunId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FileTransfer>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadEvidenceFolder(workflowRunId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.downloadEvidenceFolder']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * ID photos are downloaded using this endpoint.
          * @summary Download ID photo
          * @param {string} idPhotoId The ID photo\&#39;s unique identifier.
@@ -14491,6 +14541,16 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.downloadDocumentVideo(documentId, options).then((request) => request(axios, basePath));
         },
         /**
+         * Retrieves the evidence folder for the designated Workflow Run 
+         * @summary Retrieve Workflow Run Evidence Folder
+         * @param {string} workflowRunId Workflow Run ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        downloadEvidenceFolder(workflowRunId: string, options?: RawAxiosRequestConfig): AxiosPromise<FileTransfer> {
+            return localVarFp.downloadEvidenceFolder(workflowRunId, options).then((request) => request(axios, basePath));
+        },
+        /**
          * ID photos are downloaded using this endpoint.
          * @summary Download ID photo
          * @param {string} idPhotoId The ID photo\&#39;s unique identifier.
@@ -15199,6 +15259,18 @@ export class DefaultApi extends BaseAPI {
      */
     public downloadDocumentVideo(documentId: string, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).downloadDocumentVideo(documentId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Retrieves the evidence folder for the designated Workflow Run 
+     * @summary Retrieve Workflow Run Evidence Folder
+     * @param {string} workflowRunId Workflow Run ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public downloadEvidenceFolder(workflowRunId: string, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).downloadEvidenceFolder(workflowRunId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/configuration.ts
+++ b/configuration.ts
@@ -101,7 +101,7 @@ export class Configuration {
         this.baseOptions = {...{ timeout: 30_000 },
                             ...param.baseOptions,
                             ...{ headers: {...param.baseOptions?.headers,
-                                           ...{'User-Agent': 'onfido-node/4.4.0'}}}};
+                                           ...{'User-Agent': 'onfido-node/4.5.0'}}}};
         this.formDataCtor = param.formDataCtor || require('form-data');         // Injiect form data constructor (if needed)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onfido/api",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onfido/api",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4"
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.75.tgz",
-      "integrity": "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2775,9 +2775,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
-      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/api",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Node.js library for the Onfido API",
   "author": "OpenAPI-Generator Contributors",
   "repository": {

--- a/test/resources/workflow-runs.test.ts
+++ b/test/resources/workflow-runs.test.ts
@@ -150,3 +150,20 @@ it("downloads a timeline file", async () => {
   expect(file.headers["content-type"]).toEqual("application/pdf");
   expect(file.data.buffer.slice(0, 5)).toEqual("%PDF-");
 }, 60000);
+
+it("downloads an evidence folder", async () => {
+  const workflowRunId = (await createWorkflowRun(applicant, workflowIdTimeline))
+    .data.id;
+
+  await repeatRequestUntilStatusChanges(
+    "findWorkflowRun",
+    [workflowRunId],
+    "approved"
+  );
+
+  const file = await onfido.downloadEvidenceFolder(workflowRunId);
+
+  expect(file.status).toEqual(200);
+  expect(file.headers["content-type"]).toEqual("application/zip");
+  expect(file.data.buffer.length).toBeGreaterThan(0);
+}, 60000);


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@54ce45f2138f044cc5cb40f6904dc7bc1a675be6 (included)

Additional changes:
  - [Add downloadEvidenceFolder test](https://github.com/onfido/onfido-node/pull/154/commits/0e4015ec25a2ed5f6057d00440aa784447f9d798)