### PR TITLE
test: wait for evidence folder to be available

### DIFF
--- a/test/resources/reports.test.ts
+++ b/test/resources/reports.test.ts
@@ -6,7 +6,8 @@ import {
   createApplicant,
   uploadDocument,
   createCheck,
-  sortByReportName
+  sortByReportName,
+  repeatRequestUntilStatusChanges
 } from "../test-helpers";
 
 function getExpectedReport(exampleReport: Report, overrideProperties = {}) {
@@ -35,17 +36,21 @@ const exampleReport: Report = {
   created_at: "2020-01-01T00:00:00Z",
   name: "document",
   href: "https://api.onfido.com/v3.6/reports/123-abc",
-  status: "awaiting_data",
-  result: null,
-  sub_result: null,
+  status: "complete",
+  result: "clear",
+  sub_result: "clear",
   documents: [{ id: "document-id" }],
   check_id: "aa111111-1111-1111-1111-111111111111"
 };
 
 it("finds a report", async () => {
-  const report = await onfido.findReport(check.report_ids[1]);
+  const report: Report = await repeatRequestUntilStatusChanges(
+    "findReport",
+    [check.report_ids[1]],
+    "complete"
+  );
 
-  expect(report.data).toEqual(getExpectedReport(exampleReport));
+  expect(report).toEqual(getExpectedReport(exampleReport));
 });
 
 it("lists reports", async () => {

--- a/test/resources/workflow-runs.test.ts
+++ b/test/resources/workflow-runs.test.ts
@@ -161,7 +161,10 @@ it("downloads an evidence folder", async () => {
     "approved"
   );
 
-  const file = await onfido.downloadEvidenceFolder(workflowRunId);
+  const file = await repeatRequestUntilHttpCodeChanges(
+    "downloadEvidenceFolder",
+    [workflowRunId]
+  );
 
   expect(file.status).toEqual(200);
   expect(file.headers["content-type"]).toEqual("application/zip");

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -273,7 +273,7 @@ export async function repeatRequestUntilStatusChanges(
   fn: string,
   params: any[],
   expectedStatus: string,
-  maxRetries = 10,
+  maxRetries = 15,
   sleepTime = 1000
 ): Promise<any> {
   let instance = (await onfido[fn](...params)).data;
@@ -294,7 +294,7 @@ export async function repeatRequestUntilStatusChanges(
 export async function repeatRequestUntilTaskOutputChanges(
   fn: string,
   params: any[],
-  maxRetries = 10,
+  maxRetries = 15,
   sleepTime = 1000
 ): Promise<any> {
   let instance = (await onfido[fn](...params)).data;
@@ -315,7 +315,7 @@ export async function repeatRequestUntilTaskOutputChanges(
 export async function repeatRequestUntilHttpCodeChanges(
   fn: string,
   params: any[],
-  maxRetries: number = 10,
+  maxRetries: number = 15,
   sleepTime: number = 1000
 ): Promise<any> {
   let iteration = 0;


### PR DESCRIPTION
Evidence folder needs to be available before it can be downloaded. Fix the test by retrying the request until we no longer receive 404.

I also did some extra changes (increasing number of retries) to reduce test flakiness.