### PR TITLE
Fix CHANGELOG.md and improve CI

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -51,7 +51,8 @@ jobs:
             npx prettier -c test/**/*.ts
       - name: Run integration tests with NPM
         if: ${{ matrix.node-version == '18.x' &&
-          github.repository_owner == 'onfido' }}
+          github.repository_owner == 'onfido' &&
+          (github.event_name == 'pull_request' || github.event_name == 'release') }}
         run: npm test -- -i
         env:
           ONFIDO_API_TOKEN: ${{ secrets.ONFIDO_API_TOKEN }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,6 +18,10 @@ on:
       - published
   schedule:
     - cron: "0 12 * * 0"   # Every Sunday, at midday
+
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -66,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     environment: delivery
+    permissions:
+      contents: write
     if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - Release based on Onfido OpenAPI spec version [v5.4.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.4.0):
   - [ENT-26] Add AES document download endpoint
+- [ENT-26] Add AES documents test
 
 ## v5.3.0 11th July 2025
 
-- Release based on Onfido OpenAPI spec version [v5.3.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.3.0):
 - Release based on Onfido OpenAPI spec version [v5.3.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.3.0):
   - [DEXTV2-9494] Add manual_transmission_restriction to document with driver verification report
 


### PR DESCRIPTION
Fix CHANGELOG.md and improve CI to not run tests when commit is not coming from a PR (i.e. CHANGELOG update performed by the CI).

Take the opportunity for fixing a few security vulnerabilities:
- https://github.com/onfido/onfido-node/security/code-scanning/16
- https://github.com/onfido/onfido-node/security/code-scanning/17