### PR TITLE
Update package repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Node.js library for the Onfido API",
   "author": "OpenAPI-Generator Contributors",
   "repository": {
-    "type": "git",
-    "url": "https://github.com/onfido/onfido-node.git"
+    "url": "git+https://github.com/onfido/onfido-node.git"
   },
   "keywords": [
     "axios",


### PR DESCRIPTION
According to https://docs.npmjs.com/trusted-publishers#troubleshooting,

> To publish from GitHub, your package's repository.url field in package.json must exactly match your GitHub repository.