### PR TITLE
[CAT-2931] ci: add distributed lock for integration tests

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -50,7 +50,8 @@ jobs:
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
       - name: Run integration tests with API token auth
         if: steps.should-run-integration-tests.outputs.result == 'true'
         run: npm test -- -i
@@ -77,7 +78,8 @@ jobs:
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -52,7 +52,7 @@ jobs:
         run: echo "result=true" >> "$GITHUB_OUTPUT"
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@main
+        uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
       - name: Run integration tests with API token auth
@@ -79,7 +79,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@main
+        uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
 

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -44,12 +44,8 @@ jobs:
       - name: Should run integration tests
         id: should-run-integration-tests
         if: ${{ matrix.node-version == '20.x' &&
-          github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
+          github.repository_owner == 'onfido' }}
+        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -41,13 +41,22 @@ jobs:
         run: npm ci
       - name: Run linter over tests
         run: npx prettier -c test/**/*.ts
-      - name: Run integration tests with API token auth
+      - name: Should run integration tests
+        id: should-run-integration-tests
         if: ${{ matrix.node-version == '20.x' &&
           github.repository_owner == 'onfido' &&
           (github.event_name == 'pull_request' ||
            github.event_name == 'release' ||
            github.event_name == 'workflow_dispatch' ||
            github.event_name == 'schedule') }}
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+      - name: Acquire integration test lock
+        if: steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/acquire@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+      - name: Run integration tests with API token auth
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: npm test -- -i
         env:
           ONFIDO_API_TOKEN: ${{ secrets.ONFIDO_API_TOKEN }}
@@ -57,11 +66,8 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Run integration tests with OAuth client credentials auth
-        if: ${{ matrix.node-version == '20.x' &&
-          github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch') }}
+        if: ${{ steps.should-run-integration-tests.outputs.result == 'true' &&
+          github.event_name != 'schedule' }}
         run: npm test -- -i
         env:
           ONFIDO_OAUTH_CLIENT_ID: ${{ secrets.ONFIDO_OAUTH_CLIENT_ID }}
@@ -71,6 +77,11 @@ jobs:
           ONFIDO_SAMPLE_VIDEO_ID_2: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_2 }}
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
+      - name: Release integration test lock
+        if: always() && steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/release@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -45,10 +45,10 @@ jobs:
         id: should-run-integration-tests
         if: ${{ matrix.node-version == '20.x' &&
           github.repository_owner == 'onfido' }}
-        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
+        uses: onfido/onfido-actions/should-run-integration-tests@main
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@add-lock-action
+        uses: onfido/onfido-actions/lock/acquire@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
@@ -76,7 +76,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@add-lock-action
+        uses: onfido/onfido-actions/lock/release@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}


### PR DESCRIPTION
Prevents integration tests from running in parallel across SDK repositories by using a distributed lock via [onfido-actions/lock](https://github.com/onfido/onfido-actions).

**Changes:**
- Add `should-run-integration-tests` action to determine when tests should run
- Acquire/release a cross-repo lock around integration tests